### PR TITLE
feat: MVP de prontidão cognitiva pré-jornada B2B

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm -r --filter=./packages/* typecheck
+      - run: pnpm -r --filter=./packages/* test

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,10 @@ coverage/
 .env
 .env.local
 .env.*.local
+!.env.example
 .vercel/
 .vscode/
 .idea/
 *.tsbuildinfo
+supabase/.temp/
+supabase/.branches/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,57 @@
-# App Motoristas
+# App Motoristas — Prontidão Cognitiva Pré-Jornada
 
-Repositório da plataforma de prontidão cognitiva pré-jornada para motoristas de frota.
+Plataforma B2B para transportadoras aferirem a prontidão cognitiva de motoristas **antes** do início da jornada. Uma bateria rápida (~75 s) baseada em PVT (Psychomotor Vigilance Test) mais questionário subjetivo de sono/fadiga gera um score semafórico e — conforme política da empresa — pode bloquear a liberação do veículo.
 
-Implementação em andamento — ver branch de feature.
+> Status: MVP em desenvolvimento. Ver [`/root/.claude/plans/ja-peguei-uns-dados-quizzical-barto.md`](./docs/plan.md) ou o plano de implementação para contexto completo.
+
+## Arquitetura
+
+```
+apps/mobile        Expo (React Native) — app do motorista
+apps/dashboard     Next.js — painel do gestor da frota
+packages/shared-types    Contratos Zod compartilhados
+packages/scoring         Motor de scoring (Z-score, cutoffs) — testável puro
+packages/cognitive-tests Componentes RN de teste cognitivo (PVT, atenção, vigilância)
+supabase/migrations      Schema + RLS
+supabase/functions       Edge functions (scoring, webhook Unico)
+docs/                    DPIA/LGPD, metodologia de scoring, controles antifraude
+```
+
+Stack: React Native + Expo · Next.js 15 · Supabase (Postgres + Auth + Storage + Edge Functions) · Biometria via SaaS BR (Unico/Idwall/Serpro) · TypeScript fim-a-fim.
+
+## Quickstart
+
+```bash
+pnpm install
+pnpm test              # roda suíte unitária dos pacotes puros
+pnpm dashboard:dev     # next dev
+pnpm mobile:start      # expo start
+```
+
+Aplicar schema local:
+
+```bash
+supabase start
+supabase db reset      # aplica migrations em supabase/migrations
+```
+
+## Bateria cognitiva
+
+| Bloco | Duração | Métrica |
+|---|---|---|
+| PVT-B (reação) | 30 s | Mediana RT, lapsos (>500 ms), false starts |
+| Atenção dividida | 20 s | Acertos, omissões, falsos positivos |
+| Vigilância/consistência | 25 s | Coeficiente de variação do RT |
+
+Scoring: 60 % PVT normalizado (Z-score) + 40 % subjetivo (KSS + Samn-Perelli) → semáforo.
+
+## Compliance
+
+Biometria é dado pessoal sensível (LGPD art. 5º II). Ver:
+- [`docs/lgpd-dpia.md`](./docs/lgpd-dpia.md) — Data Protection Impact Assessment
+- [`docs/antifraud-controls.md`](./docs/antifraud-controls.md) — matriz de controles
+- [`docs/scoring-methodology.md`](./docs/scoring-methodology.md) — detalhes do motor de scoring
+
+## Licença
+
+Proprietário — todos os direitos reservados.

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_SUPABASE_URL=https://YOUR-PROJECT.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=YOUR-ANON-KEY
+# Service role key — ONLY para scripts admin (reprocessar sessões, export LGPD).
+# Nunca exponha em componentes de cliente.
+SUPABASE_SERVICE_ROLE_KEY=YOUR-SERVICE-ROLE-KEY

--- a/apps/dashboard/next.config.mjs
+++ b/apps/dashboard/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['@app-motoristas/shared-types'],
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@app-motoristas/dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@app-motoristas/shared-types": "workspace:*",
+    "@supabase/ssr": "0.5.2",
+    "@supabase/supabase-js": "2.46.1",
+    "next": "15.0.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "22.9.0",
+    "@types/react": "18.3.12",
+    "@types/react-dom": "18.3.1",
+    "eslint": "8.57.1",
+    "eslint-config-next": "15.0.3",
+    "typescript": "5.6.3"
+  }
+}

--- a/apps/dashboard/src/app/drivers/page.tsx
+++ b/apps/dashboard/src/app/drivers/page.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getSupabaseServerClient } from '@/lib/supabase-server';
+
+interface Row {
+  driver_id: string;
+  full_name: string;
+  driver_status: string;
+  session_id: string | null;
+  started_at: string | null;
+  traffic_light: 'green' | 'yellow' | 'red' | null;
+  final_score: number | null;
+  blocked: boolean | null;
+}
+
+export default async function DriversPage() {
+  const supabase = await getSupabaseServerClient();
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth.user) redirect('/login');
+
+  const { data, error } = await supabase
+    .from('v_driver_latest_session')
+    .select('*')
+    .order('started_at', { ascending: false, nullsFirst: false });
+
+  const rows = (data ?? []) as Row[];
+
+  return (
+    <main className="page">
+      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+        <div>
+          <h1 style={{ margin: 0, fontSize: 24 }}>Motoristas</h1>
+          <p style={{ color: 'var(--muted)', margin: '4px 0 0' }}>Prontidão do último teste.</p>
+        </div>
+        <Link href="/drivers/new" className="badge badge-neutral" style={{ padding: '8px 14px' }}>
+          + Convidar motorista
+        </Link>
+      </header>
+
+      {error ? (
+        <div className="card" style={{ color: 'var(--red)' }}>
+          Erro ao carregar: {error.message}
+        </div>
+      ) : null}
+
+      <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+        <table>
+          <thead>
+            <tr>
+              <th>Motorista</th>
+              <th>Status</th>
+              <th>Último teste</th>
+              <th>Score</th>
+              <th>Semáforo</th>
+              <th>Bloqueado?</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.driver_id}>
+                <td>{r.full_name}</td>
+                <td>
+                  <span className={`badge badge-${r.driver_status === 'active' ? 'green' : 'neutral'}`}>
+                    {r.driver_status}
+                  </span>
+                </td>
+                <td>{r.started_at ? new Date(r.started_at).toLocaleString('pt-BR') : '—'}</td>
+                <td>{r.final_score != null ? Math.round(r.final_score) : '—'}</td>
+                <td>
+                  {r.traffic_light ? <span className={`badge badge-${r.traffic_light}`}>{r.traffic_light}</span> : '—'}
+                </td>
+                <td>
+                  {r.blocked === true ? (
+                    <span className="badge badge-red">sim</span>
+                  ) : r.blocked === false ? (
+                    <span className="badge badge-green">não</span>
+                  ) : (
+                    '—'
+                  )}
+                </td>
+                <td style={{ textAlign: 'right' }}>
+                  {r.session_id ? <Link href={`/sessions/${r.session_id}`}>Ver sessão →</Link> : null}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={7} style={{ textAlign: 'center', color: 'var(--muted)', padding: 32 }}>
+                  Nenhum motorista cadastrado ainda.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/src/app/globals.css
+++ b/apps/dashboard/src/app/globals.css
@@ -1,0 +1,39 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --border: #334155;
+  --text: #f1f5f9;
+  --muted: #94a3b8;
+  --primary: #3b82f6;
+  --green: #22c55e;
+  --yellow: #eab308;
+  --red: #ef4444;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+a { color: var(--primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 12px; text-align: left; border-bottom: 1px solid var(--border); }
+th { color: var(--muted); font-weight: 600; text-transform: uppercase; font-size: 12px; letter-spacing: 0.05em; }
+
+.page { max-width: 1100px; margin: 0 auto; padding: 32px 24px; }
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px; }
+
+.badge { display: inline-flex; align-items: center; padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+.badge-green { background: rgba(34,197,94,0.15); color: var(--green); }
+.badge-yellow { background: rgba(234,179,8,0.15); color: var(--yellow); }
+.badge-red { background: rgba(239,68,68,0.15); color: var(--red); }
+.badge-neutral { background: rgba(148,163,184,0.15); color: var(--muted); }

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Prontidão Motoristas — Painel',
+  description: 'Gestão de prontidão cognitiva pré-jornada da sua frota.',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="pt-BR">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/dashboard/src/app/login/page.tsx
+++ b/apps/dashboard/src/app/login/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createBrowserClient } from '@supabase/ssr';
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    const supabase = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    );
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setLoading(false);
+    if (error) setError(error.message);
+    else router.push('/drivers');
+  }
+
+  return (
+    <main className="page" style={{ maxWidth: 420 }}>
+      <h1>Entrar no painel</h1>
+      <form onSubmit={submit} className="card" style={{ display: 'grid', gap: 12 }}>
+        <label>
+          <div style={{ color: 'var(--muted)', fontSize: 12 }}>E-mail</div>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            style={inputStyle}
+          />
+        </label>
+        <label>
+          <div style={{ color: 'var(--muted)', fontSize: 12 }}>Senha</div>
+          <input
+            type="password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            style={inputStyle}
+          />
+        </label>
+        {error ? <p style={{ color: 'var(--red)' }}>{error}</p> : null}
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            background: 'var(--primary)',
+            color: '#fff',
+            padding: '10px 16px',
+            border: 'none',
+            borderRadius: 8,
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          {loading ? 'Entrando…' : 'Entrar'}
+        </button>
+      </form>
+    </main>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 12px',
+  borderRadius: 8,
+  border: '1px solid var(--border)',
+  background: 'var(--bg)',
+  color: 'var(--text)',
+  fontSize: 14,
+};

--- a/apps/dashboard/src/app/page.tsx
+++ b/apps/dashboard/src/app/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getSupabaseServerClient } from '@/lib/supabase-server';
+
+export default async function Home() {
+  const supabase = await getSupabaseServerClient();
+  const { data } = await supabase.auth.getUser();
+  if (!data.user) redirect('/login');
+  redirect('/drivers');
+  return (
+    <div className="page">
+      <Link href="/drivers">Ir para motoristas</Link>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/sessions/[id]/page.tsx
+++ b/apps/dashboard/src/app/sessions/[id]/page.tsx
@@ -1,0 +1,120 @@
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import { getSupabaseServerClient } from '@/lib/supabase-server';
+
+export default async function SessionDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = await getSupabaseServerClient();
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth.user) redirect('/login');
+
+  const [{ data: session }, { data: score }, { data: cognitive }, { data: subjective }] =
+    await Promise.all([
+      supabase.from('sessions').select('*, drivers(full_name,cpf,cnh_number)').eq('id', id).maybeSingle(),
+      supabase.from('session_scores').select('*').eq('session_id', id).maybeSingle(),
+      supabase.from('cognitive_results').select('*').eq('session_id', id),
+      supabase.from('subjective_results').select('*').eq('session_id', id).maybeSingle(),
+    ]);
+
+  if (!session) notFound();
+
+  const light = (score?.traffic_light ?? 'neutral') as 'green' | 'yellow' | 'red' | 'neutral';
+
+  return (
+    <main className="page">
+      <Link href="/drivers" style={{ color: 'var(--muted)' }}>
+        ← Voltar
+      </Link>
+      <header style={{ marginTop: 12, marginBottom: 24 }}>
+        <h1 style={{ margin: 0 }}>{session.drivers?.full_name ?? 'Motorista'}</h1>
+        <p style={{ color: 'var(--muted)', margin: '4px 0 0' }}>
+          Sessão {id.slice(0, 8)} · {new Date(session.started_at).toLocaleString('pt-BR')}
+        </p>
+      </header>
+
+      <section style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 16, marginBottom: 24 }}>
+        <div className="card">
+          <div style={{ color: 'var(--muted)', fontSize: 12, textTransform: 'uppercase' }}>Score final</div>
+          <div style={{ fontSize: 40, fontWeight: 700 }}>
+            {score?.final_score != null ? Math.round(score.final_score) : '—'}
+          </div>
+          <span className={`badge badge-${light}`}>{light}</span>
+        </div>
+        <div className="card">
+          <div style={{ color: 'var(--muted)', fontSize: 12, textTransform: 'uppercase' }}>Objetivo (PVT)</div>
+          <div style={{ fontSize: 24, fontWeight: 600 }}>
+            {score?.objective_score != null ? Math.round(score.objective_score) : '—'}
+          </div>
+        </div>
+        <div className="card">
+          <div style={{ color: 'var(--muted)', fontSize: 12, textTransform: 'uppercase' }}>Subjetivo</div>
+          <div style={{ fontSize: 24, fontWeight: 600 }}>
+            {score?.subjective_score != null ? Math.round(score.subjective_score) : '—'}
+          </div>
+        </div>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 18 }}>Blocos cognitivos</h2>
+        <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+          <table>
+            <thead>
+              <tr>
+                <th>Bloco</th>
+                <th>Mediana RT (ms)</th>
+                <th>Lapsos (%)</th>
+                <th>CV RT</th>
+                <th>Z-score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(cognitive ?? []).map((row) => (
+                <tr key={row.id}>
+                  <td>{row.block}</td>
+                  <td>{Math.round(Number(row.median_rt_ms))}</td>
+                  <td>{(Number(row.lapse_rate) * 100).toFixed(1)}</td>
+                  <td>{Number(row.cv_rt).toFixed(3)}</td>
+                  <td>{Number(row.z_score).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 18 }}>Questionário subjetivo</h2>
+        <div className="card">
+          <p style={{ margin: 0 }}>
+            KSS (sonolência): <strong>{subjective?.kss ?? '—'} / 9</strong>
+          </p>
+          <p style={{ margin: '8px 0 0' }}>
+            Samn-Perelli (cansaço): <strong>{subjective?.samn_perelli ?? '—'} / 7</strong>
+          </p>
+          {subjective?.hours_slept != null ? (
+            <p style={{ margin: '8px 0 0' }}>Horas de sono relatadas: {subjective.hours_slept}h</p>
+          ) : null}
+        </div>
+      </section>
+
+      <section>
+        <h2 style={{ fontSize: 18 }}>Antifraude</h2>
+        <div className="card">
+          <p style={{ margin: 0 }}>
+            Liveness: <strong>{session.liveness_match_score ?? '—'}%</strong>
+          </p>
+          <p style={{ margin: '8px 0 0' }}>Device: {session.device_fingerprint.slice(0, 16)}…</p>
+          <p style={{ margin: '8px 0 0' }}>
+            Geofence: <strong>{session.inside_geofence == null ? '—' : session.inside_geofence ? 'OK' : 'FORA'}</strong>
+          </p>
+          {session.liveness_video_ref ? (
+            <p style={{ margin: '8px 0 0' }}>
+              Vídeo de liveness:{' '}
+              <code style={{ color: 'var(--muted)' }}>{session.liveness_video_ref}</code>
+            </p>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/dashboard/src/lib/supabase-server.ts
+++ b/apps/dashboard/src/lib/supabase-server.ts
@@ -1,0 +1,22 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+export async function getSupabaseServerClient() {
+  const cookieStore = await cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(items) {
+          for (const { name, value, options } of items) {
+            cookieStore.set(name, value, options);
+          }
+        },
+      },
+    },
+  );
+}

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowJs": false,
+    "noEmit": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,0 +1,5 @@
+EXPO_PUBLIC_SUPABASE_URL=https://YOUR-PROJECT.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=YOUR-ANON-KEY
+# Provider de biometria (Unico, Idwall ou Serpro). Chaves NUNCA ficam no app —
+# apenas o token de sessão emitido pelo backend após validação server-side.
+EXPO_PUBLIC_BIOMETRIC_PROVIDER=unico

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,0 +1,50 @@
+{
+  "expo": {
+    "name": "Prontidão Motorista",
+    "slug": "app-motoristas",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "scheme": "motoristas",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#0f172a"
+    },
+    "ios": {
+      "supportsTablet": false,
+      "bundleIdentifier": "com.appmotoristas.driver",
+      "infoPlist": {
+        "NSCameraUsageDescription": "Usamos a câmera para verificar sua identidade (biometria facial) antes do teste de prontidão, protegendo sua jornada e a empresa contra fraudes.",
+        "NSLocationWhenInUseUsageDescription": "Confirmamos que o teste é realizado no local de início da jornada (geofencing)."
+      }
+    },
+    "android": {
+      "package": "com.appmotoristas.driver",
+      "permissions": ["CAMERA", "ACCESS_FINE_LOCATION"],
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#0f172a"
+      }
+    },
+    "plugins": [
+      "expo-router",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Permita o uso da câmera para a verificação facial antifraude."
+        }
+      ],
+      [
+        "expo-location",
+        {
+          "locationAlwaysAndWhenInUsePermission": "Permita o acesso à localização para validar o ponto de partida."
+        }
+      ]
+    ],
+    "experiments": {
+      "typedRoutes": true
+    }
+  }
+}

--- a/apps/mobile/app/(auth)/_layout.tsx
+++ b/apps/mobile/app/(auth)/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function AuthLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Alert, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { supabase } from '@/lib/supabase';
+import { colors, styles } from '@/lib/theme';
+
+// Simplified onboarding for MVP: SMS-based login via Supabase Phone Auth.
+// The full flow also captures a CNH photo and posts to the biometric provider
+// (Unico / Idwall / Serpro) via a secure backend endpoint — see
+// supabase/functions/unico-webhook/index.ts for the server-side match.
+export default function Onboarding() {
+  const router = useRouter();
+  const [phone, setPhone] = useState('');
+  const [code, setCode] = useState('');
+  const [step, setStep] = useState<'phone' | 'code'>('phone');
+  const [loading, setLoading] = useState(false);
+
+  async function sendOtp() {
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithOtp({ phone });
+    setLoading(false);
+    if (error) Alert.alert('Erro', error.message);
+    else setStep('code');
+  }
+
+  async function verifyOtp() {
+    setLoading(true);
+    const { error } = await supabase.auth.verifyOtp({ phone, token: code, type: 'sms' });
+    setLoading(false);
+    if (error) {
+      Alert.alert('Erro', error.message);
+      return;
+    }
+    // Next: kick off biometric onboarding (CNH photo → provider → webhook).
+    // That flow lives at /(auth)/biometric — stub for now.
+    router.replace('/(session)/pre-journey');
+  }
+
+  return (
+    <SafeAreaView style={styles.screen}>
+      <View style={styles.center}>
+        <Text style={styles.title}>Prontidão Motorista</Text>
+        <Text style={styles.subtitle}>
+          Entre com o telefone cadastrado pela sua empresa.
+        </Text>
+
+        {step === 'phone' ? (
+          <>
+            <TextInput
+              style={inputStyle}
+              placeholder="+55 11 99999-0000"
+              placeholderTextColor={colors.textMuted}
+              keyboardType="phone-pad"
+              autoComplete="tel"
+              value={phone}
+              onChangeText={setPhone}
+            />
+            <TouchableOpacity
+              style={[styles.button, { opacity: loading || phone.length < 10 ? 0.5 : 1 }]}
+              disabled={loading || phone.length < 10}
+              onPress={sendOtp}
+            >
+              <Text style={styles.buttonText}>Receber código SMS</Text>
+            </TouchableOpacity>
+          </>
+        ) : (
+          <>
+            <TextInput
+              style={inputStyle}
+              placeholder="Código de 6 dígitos"
+              placeholderTextColor={colors.textMuted}
+              keyboardType="number-pad"
+              maxLength={6}
+              value={code}
+              onChangeText={setCode}
+            />
+            <TouchableOpacity
+              style={[styles.button, { opacity: loading || code.length !== 6 ? 0.5 : 1 }]}
+              disabled={loading || code.length !== 6}
+              onPress={verifyOtp}
+            >
+              <Text style={styles.buttonText}>Confirmar e continuar</Text>
+            </TouchableOpacity>
+          </>
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const inputStyle = {
+  width: '100%' as const,
+  backgroundColor: colors.surface,
+  color: colors.text,
+  padding: 14,
+  borderRadius: 12,
+  fontSize: 16,
+  marginBottom: 16,
+  borderWidth: 1,
+  borderColor: colors.border,
+};

--- a/apps/mobile/app/(session)/_layout.tsx
+++ b/apps/mobile/app/(session)/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function SessionLayout() {
+  return <Stack screenOptions={{ headerShown: false, gestureEnabled: false }} />;
+}

--- a/apps/mobile/app/(session)/liveness.tsx
+++ b/apps/mobile/app/(session)/liveness.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from 'react';
+import { Alert, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import { useRouter } from 'expo-router';
+import { colors, styles } from '@/lib/theme';
+
+// Active liveness challenge: the driver must follow a random sequence of
+// prompts (blink / turn head left / turn head right). In production this
+// screen delegates capture + server-side match to the Unico / Idwall / Serpro
+// SDK (see docs/antifraud-controls.md). The component below is a placeholder
+// that records ~3s of video and advances — enough to wire the flow.
+const PROMPTS = ['Olhe para frente', 'Pisque devagar', 'Vire o rosto para a direita'] as const;
+
+export default function Liveness() {
+  const router = useRouter();
+  const [permission, requestPermission] = useCameraPermissions();
+  const [currentPrompt, setCurrentPrompt] = useState(0);
+  const [recording, setRecording] = useState(false);
+  const cameraRef = useRef<CameraView | null>(null);
+
+  useEffect(() => {
+    if (!permission?.granted) requestPermission();
+  }, [permission, requestPermission]);
+
+  useEffect(() => {
+    if (currentPrompt >= PROMPTS.length) {
+      router.replace('/(session)/test-pvt');
+    }
+  }, [currentPrompt, router]);
+
+  async function handleNext() {
+    if (!cameraRef.current) return;
+    if (!recording) {
+      setRecording(true);
+      // Production: cameraRef.current.recordAsync and upload to storage bucket.
+      // For MVP, we just advance the prompt after a short delay.
+      setTimeout(() => {
+        setRecording(false);
+        setCurrentPrompt((p) => p + 1);
+      }, 1200);
+    }
+  }
+
+  if (!permission) return null;
+  if (!permission.granted) {
+    return (
+      <SafeAreaView style={styles.screen}>
+        <View style={styles.center}>
+          <Text style={styles.title}>Acesso à câmera</Text>
+          <Text style={styles.subtitle}>Precisamos da câmera para verificar sua identidade.</Text>
+          <TouchableOpacity style={styles.button} onPress={() => requestPermission()}>
+            <Text style={styles.buttonText}>Permitir</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const prompt = PROMPTS[currentPrompt] ?? '';
+
+  return (
+    <SafeAreaView style={styles.screen}>
+      <View style={{ flex: 1, paddingVertical: 20 }}>
+        <Text style={styles.title}>Verificação facial</Text>
+        <Text style={styles.subtitle}>{prompt}</Text>
+        <View
+          style={{
+            flex: 1,
+            borderRadius: 16,
+            overflow: 'hidden',
+            borderWidth: recording ? 3 : 1,
+            borderColor: recording ? colors.red : colors.border,
+            marginBottom: 24,
+          }}
+        >
+          <CameraView ref={cameraRef} style={{ flex: 1 }} facing="front" mode="video" />
+        </View>
+        <TouchableOpacity
+          style={[styles.button, { opacity: recording ? 0.5 : 1 }]}
+          disabled={recording}
+          onPress={handleNext}
+        >
+          <Text style={styles.buttonText}>{recording ? 'Capturando…' : 'Continuar'}</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile/app/(session)/pre-journey.tsx
+++ b/apps/mobile/app/(session)/pre-journey.tsx
@@ -1,0 +1,52 @@
+import { Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { colors, styles } from '@/lib/theme';
+
+export default function PreJourney() {
+  const router = useRouter();
+  return (
+    <SafeAreaView style={styles.screen}>
+      <View style={styles.center}>
+        <Text style={styles.title}>Pronto para iniciar?</Text>
+        <Text style={styles.subtitle}>
+          O teste leva cerca de 90 segundos: verificação facial, 3 desafios rápidos e 2 perguntas sobre seu sono.
+        </Text>
+
+        <View style={[styles.card, { width: '100%', marginBottom: 24 }]}>
+          <Step n={1} title="Verificação facial" desc="Confirmamos sua identidade contra a CNH." />
+          <Step n={2} title="Teste de atenção" desc="Toque rápido quando o círculo acender." />
+          <Step n={3} title="Questionário rápido" desc="Como está seu sono e cansaço hoje?" />
+        </View>
+
+        <TouchableOpacity style={styles.button} onPress={() => router.push('/(session)/liveness')}>
+          <Text style={styles.buttonText}>Começar</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function Step({ n, title, desc }: { n: number; title: string; desc: string }) {
+  return (
+    <View style={{ flexDirection: 'row', marginBottom: 14, alignItems: 'flex-start' }}>
+      <View
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 14,
+          backgroundColor: colors.primary,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginRight: 12,
+        }}
+      >
+        <Text style={{ color: '#fff', fontWeight: '700' }}>{n}</Text>
+      </View>
+      <View style={{ flex: 1 }}>
+        <Text style={{ color: colors.text, fontSize: 16, fontWeight: '600' }}>{title}</Text>
+        <Text style={{ color: colors.textMuted, fontSize: 14 }}>{desc}</Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/(session)/subjective.tsx
+++ b/apps/mobile/app/(session)/subjective.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { colors, styles } from '@/lib/theme';
+import { setSubjective } from '@/state/session-store';
+
+// Karolinska Sleepiness Scale (1-9) + Samn-Perelli fatigue (1-7).
+// Validated Portuguese translations available; the MVP inlines the short
+// anchor labels. Full versions live at docs/scoring-methodology.md.
+const KSS_LABELS: Record<number, string> = {
+  1: 'Muito alerta',
+  3: 'Alerta',
+  5: 'Nem alerta nem sonolento',
+  7: 'Sonolento — fazendo esforço',
+  9: 'Extremamente sonolento',
+};
+
+const SAMN_LABELS: Record<number, string> = {
+  1: 'Totalmente alerta',
+  3: 'OK, mas um pouco cansado',
+  5: 'Moderadamente cansado',
+  7: 'Completamente exausto',
+};
+
+export default function Subjective() {
+  const router = useRouter();
+  const [kss, setKss] = useState<number | null>(null);
+  const [sp, setSp] = useState<number | null>(null);
+
+  function submit() {
+    if (kss == null || sp == null) return;
+    setSubjective({ kss, samnPerelli: sp });
+    router.replace('/(session)/submit');
+  }
+
+  return (
+    <SafeAreaView style={styles.screen}>
+      <ScrollView contentContainerStyle={{ paddingVertical: 20 }}>
+        <Text style={styles.title}>Como você está?</Text>
+        <Text style={styles.subtitle}>Suas respostas entram no score — seja honesto.</Text>
+
+        <Text style={sectionTitle}>Nível de sonolência</Text>
+        <Scale count={9} selected={kss} onSelect={setKss} labels={KSS_LABELS} />
+
+        <Text style={sectionTitle}>Nível de cansaço físico/mental</Text>
+        <Scale count={7} selected={sp} onSelect={setSp} labels={SAMN_LABELS} />
+
+        <TouchableOpacity
+          style={[styles.button, { marginTop: 24, opacity: kss == null || sp == null ? 0.5 : 1 }]}
+          disabled={kss == null || sp == null}
+          onPress={submit}
+        >
+          <Text style={styles.buttonText}>Enviar respostas</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const sectionTitle = {
+  color: colors.text,
+  fontSize: 18,
+  fontWeight: '600' as const,
+  marginTop: 16,
+  marginBottom: 12,
+};
+
+function Scale({
+  count,
+  selected,
+  onSelect,
+  labels,
+}: {
+  count: number;
+  selected: number | null;
+  onSelect: (n: number) => void;
+  labels: Record<number, string>;
+}) {
+  const items = Array.from({ length: count }, (_, i) => i + 1);
+  return (
+    <View>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+        {items.map((n) => {
+          const active = selected === n;
+          return (
+            <TouchableOpacity
+              key={n}
+              onPress={() => onSelect(n)}
+              style={{
+                width: 44,
+                height: 44,
+                borderRadius: 22,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: active ? colors.primary : colors.surface,
+                borderWidth: 1,
+                borderColor: active ? colors.primary : colors.border,
+              }}
+            >
+              <Text style={{ color: active ? '#fff' : colors.text, fontWeight: '600' }}>{n}</Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+      {selected != null && labels[selected] != null ? (
+        <Text style={{ color: colors.textMuted, marginTop: 10, fontSize: 14 }}>
+          {selected}: {labels[selected]}
+        </Text>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/app/(session)/submit.tsx
+++ b/apps/mobile/app/(session)/submit.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import * as Location from 'expo-location';
+import Constants from 'expo-constants';
+import type { SessionScore } from '@app-motoristas/shared-types';
+import { colors, styles } from '@/lib/theme';
+import { clearDraft, getDraft } from '@/state/session-store';
+import { supabase } from '@/lib/supabase';
+import { getDeviceFingerprint } from '@/lib/device';
+
+export default function Submit() {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [score, setScore] = useState<SessionScore | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const draft = getDraft();
+        if (!draft.subjective || draft.blocks.length === 0) {
+          throw new Error('Dados da sessão incompletos.');
+        }
+
+        const { data: userRes } = await supabase.auth.getUser();
+        if (!userRes.user) throw new Error('Sessão expirada — faça login novamente.');
+
+        let geo: { lat: number; lng: number; accuracyM?: number } | null = null;
+        const perm = await Location.requestForegroundPermissionsAsync();
+        if (perm.granted) {
+          const pos = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+          geo = { lat: pos.coords.latitude, lng: pos.coords.longitude, accuracyM: pos.coords.accuracy ?? undefined };
+        }
+
+        const submission = {
+          sessionId: draft.sessionId,
+          driverId: userRes.user.id,
+          startedAt: draft.startedAt,
+          completedAt: new Date().toISOString(),
+          deviceFingerprint: await getDeviceFingerprint(),
+          appVersion: Constants.expoConfig?.version ?? '0.0.0',
+          geo,
+          livenessVideoRef: draft.livenessVideoRef ?? null,
+          livenessMatchScore: null,
+          blocks: draft.blocks,
+          subjective: draft.subjective,
+        };
+
+        const { data, error: invokeError } = await supabase.functions.invoke<SessionScore>(
+          'compute-session-score',
+          { body: submission },
+        );
+        if (invokeError || !data) throw invokeError ?? new Error('Falha ao calcular score.');
+        setScore(data);
+        clearDraft();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+  }, []);
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.screen}>
+        <View style={styles.center}>
+          <Text style={[styles.title, { color: colors.red }]}>Erro ao enviar</Text>
+          <Text style={styles.subtitle}>{error}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!score) {
+    return (
+      <SafeAreaView style={styles.screen}>
+        <View style={styles.center}>
+          <ActivityIndicator color={colors.primary} size="large" />
+          <Text style={[styles.subtitle, { marginTop: 16 }]}>Calculando sua prontidão…</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const lightColor =
+    score.trafficLight === 'green' ? colors.green : score.trafficLight === 'yellow' ? colors.yellow : colors.red;
+
+  return (
+    <SafeAreaView style={styles.screen}>
+      <View style={styles.center}>
+        <View
+          style={{
+            width: 180,
+            height: 180,
+            borderRadius: 90,
+            backgroundColor: lightColor,
+            alignItems: 'center',
+            justifyContent: 'center',
+            marginBottom: 24,
+          }}
+        >
+          <Text style={{ color: '#fff', fontSize: 52, fontWeight: '800' }}>{Math.round(score.finalScore)}</Text>
+        </View>
+        <Text style={styles.title}>{trafficLabel(score.trafficLight)}</Text>
+        <Text style={styles.subtitle}>
+          {score.blocked
+            ? 'Sua jornada foi bloqueada pela política da empresa. Fale com o supervisor.'
+            : 'Boa jornada! Dirija com segurança.'}
+        </Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function trafficLabel(l: 'green' | 'yellow' | 'red'): string {
+  if (l === 'green') return 'Apto para a jornada';
+  if (l === 'yellow') return 'Atenção — prontidão reduzida';
+  return 'Prontidão crítica';
+}

--- a/apps/mobile/app/(session)/test-pvt.tsx
+++ b/apps/mobile/app/(session)/test-pvt.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { createPvtController, type PvtController } from '@app-motoristas/cognitive-tests';
+import type { BlockResult } from '@app-motoristas/shared-types';
+import { colors, styles } from '@/lib/theme';
+import { addBlockResult } from '@/state/session-store';
+
+// MVP PVT-B screen. Timing uses performance.now() which on Hermes is backed by
+// a high-resolution timer. For production-grade precision, migrate the stimulus
+// render + tap handler into a reanimated worklet (see plan.md risks).
+export default function TestPvt() {
+  const router = useRouter();
+  const [phase, setPhase] = useState<'idle' | 'running' | 'done'>('idle');
+  const [stimulusVisible, setStimulusVisible] = useState(false);
+  const [status, setStatus] = useState<'waiting' | 'go' | 'too_soon' | 'ok' | 'slow'>('waiting');
+  const [elapsed, setElapsed] = useState(0);
+  const controllerRef = useRef<PvtController | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const startMsRef = useRef(0);
+
+  useEffect(() => () => cancelTick(), []);
+
+  function cancelTick() {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }
+
+  function begin() {
+    const c = createPvtController({
+      block: 'pvt_b',
+      totalDurationMs: 30_000,
+      minIsiMs: 2_000,
+      maxIsiMs: 6_000,
+      stimulusTimeoutMs: 1_500,
+      lapseThresholdMs: 500,
+      falseStartWindowMs: 150,
+    });
+    controllerRef.current = c;
+
+    c.subscribe((event) => {
+      if (event.type === 'stimulus') {
+        setStimulusVisible(true);
+        setStatus('go');
+      } else if (event.type === 'response') {
+        setStimulusVisible(false);
+        setStatus(event.trial.isLapse ? 'slow' : 'ok');
+      } else if (event.type === 'miss') {
+        setStimulusVisible(false);
+        setStatus('slow');
+      } else if (event.type === 'false_start') {
+        setStatus('too_soon');
+      } else if (event.type === 'awaiting') {
+        setStatus('waiting');
+      } else if (event.type === 'complete') {
+        const result: BlockResult = event.result;
+        addBlockResult(result);
+        setPhase('done');
+        cancelTick();
+        router.replace('/(session)/subjective');
+      }
+    });
+
+    setPhase('running');
+    startMsRef.current = performance.now();
+    c.start(startMsRef.current);
+
+    const loop = () => {
+      if (!controllerRef.current?.isRunning()) return;
+      const now = performance.now();
+      controllerRef.current.tick(now);
+      setElapsed(now - startMsRef.current);
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+  }
+
+  function onTap() {
+    controllerRef.current?.onTap(performance.now());
+  }
+
+  if (phase === 'idle') {
+    return (
+      <SafeAreaView style={styles.screen}>
+        <View style={styles.center}>
+          <Text style={styles.title}>Teste de atenção</Text>
+          <Text style={styles.subtitle}>
+            Toque em qualquer lugar da tela assim que o círculo ficar verde. Aguarde o sinal —
+            toques antes contam como erro.
+          </Text>
+          <TouchableOpacity style={styles.button} onPress={begin}>
+            <Text style={styles.buttonText}>Começar (30 s)</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const remaining = Math.max(0, 30 - Math.floor(elapsed / 1000));
+
+  return (
+    <TouchableOpacity activeOpacity={1} onPress={onTap} style={styles.screen}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <View style={{ alignItems: 'center', paddingVertical: 16 }}>
+          <Text style={{ color: colors.textMuted, fontSize: 14 }}>Tempo restante</Text>
+          <Text style={{ color: colors.text, fontSize: 32, fontWeight: '700' }}>{remaining}s</Text>
+        </View>
+        <View style={styles.center}>
+          <View
+            style={{
+              width: 200,
+              height: 200,
+              borderRadius: 100,
+              backgroundColor: stimulusVisible ? colors.green : colors.surface,
+              borderWidth: 2,
+              borderColor: colors.border,
+            }}
+          />
+          <Text style={{ color: statusColor(status), marginTop: 24, fontSize: 16, fontWeight: '600' }}>
+            {statusLabel(status)}
+          </Text>
+        </View>
+      </SafeAreaView>
+    </TouchableOpacity>
+  );
+}
+
+function statusLabel(s: 'waiting' | 'go' | 'too_soon' | 'ok' | 'slow'): string {
+  switch (s) {
+    case 'waiting':
+      return 'Aguarde o sinal…';
+    case 'go':
+      return 'TOQUE!';
+    case 'ok':
+      return 'Boa! Próximo vem em instantes…';
+    case 'slow':
+      return 'Resposta lenta — continue';
+    case 'too_soon':
+      return 'Toque antes do tempo — aguarde';
+  }
+}
+
+function statusColor(s: ReturnType<typeof statusLabel> extends string ? Parameters<typeof statusLabel>[0] : never): string {
+  switch (s) {
+    case 'go':
+      return colors.green;
+    case 'too_soon':
+    case 'slow':
+      return colors.yellow;
+    default:
+      return colors.textMuted;
+  }
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,0 +1,16 @@
+import { Stack } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+export default function RootLayout() {
+  return (
+    <SafeAreaProvider>
+      <StatusBar style="light" />
+      <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: '#0f172a' } }}>
+        <Stack.Screen name="index" />
+        <Stack.Screen name="(auth)" />
+        <Stack.Screen name="(session)" />
+      </Stack>
+    </SafeAreaProvider>
+  );
+}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { supabase } from '@/lib/supabase';
+import { colors } from '@/lib/theme';
+
+export default function Gateway() {
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        router.replace('/(session)/pre-journey');
+      } else {
+        router.replace('/(auth)/onboarding');
+      }
+    })();
+  }, [router]);
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.bg }}>
+      <ActivityIndicator color={colors.primary} />
+    </View>
+  );
+}

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@app-motoristas/mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@app-motoristas/cognitive-tests": "workspace:*",
+    "@app-motoristas/scoring": "workspace:*",
+    "@app-motoristas/shared-types": "workspace:*",
+    "@supabase/supabase-js": "2.46.1",
+    "expo": "~51.0.39",
+    "expo-application": "~5.9.1",
+    "expo-camera": "~15.0.16",
+    "expo-constants": "~16.0.2",
+    "expo-crypto": "~13.0.2",
+    "expo-device": "~6.0.2",
+    "expo-linking": "~6.3.1",
+    "expo-location": "~17.0.1",
+    "expo-router": "~3.5.24",
+    "expo-secure-store": "~13.0.2",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.3.1",
+    "react-native": "0.74.5",
+    "react-native-gesture-handler": "~2.16.1",
+    "react-native-reanimated": "~3.10.1",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "3.31.1",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@types/react": "~18.3.12",
+    "typescript": "5.6.3"
+  }
+}

--- a/apps/mobile/src/lib/device.ts
+++ b/apps/mobile/src/lib/device.ts
@@ -1,0 +1,22 @@
+import * as Application from 'expo-application';
+import * as Crypto from 'expo-crypto';
+import * as Device from 'expo-device';
+import { Platform } from 'react-native';
+
+// Stable per-install device fingerprint. Combines OS install id + hardware
+// string + app id and hashes, so the raw installation id never leaves the
+// device unhashed. Used for device binding + anti-fraud telemetry.
+export async function getDeviceFingerprint(): Promise<string> {
+  const installId =
+    Platform.OS === 'android'
+      ? await Application.getAndroidId()
+      : await Application.getIosIdForVendorAsync();
+  const parts = [
+    installId ?? 'unknown-install',
+    Device.modelName ?? 'unknown-model',
+    Device.osName ?? Platform.OS,
+    Device.osVersion ?? 'unknown-os',
+    Application.applicationId ?? 'unknown-app',
+  ];
+  return Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, parts.join('|'));
+}

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -1,0 +1,26 @@
+import { createClient } from '@supabase/supabase-js';
+import * as SecureStore from 'expo-secure-store';
+
+const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!url || !anonKey) {
+  throw new Error(
+    'Supabase env vars missing. Copy .env.example to .env.local and fill EXPO_PUBLIC_SUPABASE_URL / _ANON_KEY.',
+  );
+}
+
+const secureStorageAdapter = {
+  getItem: (key: string) => SecureStore.getItemAsync(key),
+  setItem: (key: string, value: string) => SecureStore.setItemAsync(key, value),
+  removeItem: (key: string) => SecureStore.deleteItemAsync(key),
+};
+
+export const supabase = createClient(url, anonKey, {
+  auth: {
+    storage: secureStorageAdapter,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});

--- a/apps/mobile/src/lib/theme.ts
+++ b/apps/mobile/src/lib/theme.ts
@@ -1,0 +1,57 @@
+import { StyleSheet } from 'react-native';
+
+export const colors = {
+  bg: '#0f172a',
+  surface: '#1e293b',
+  border: '#334155',
+  text: '#f1f5f9',
+  textMuted: '#94a3b8',
+  primary: '#3b82f6',
+  green: '#22c55e',
+  yellow: '#eab308',
+  red: '#ef4444',
+};
+
+export const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    paddingHorizontal: 20,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: colors.textMuted,
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: colors.primary,
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 16,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+});

--- a/apps/mobile/src/state/session-store.ts
+++ b/apps/mobile/src/state/session-store.ts
@@ -1,0 +1,57 @@
+import type { BlockResult, SubjectiveAnswers } from '@app-motoristas/shared-types';
+
+// Very small in-memory session cache. Good enough for MVP (single flow).
+// Promote to Zustand if we need persistence across reloads.
+interface SessionDraft {
+  sessionId: string;
+  startedAt: string;
+  blocks: BlockResult[];
+  subjective?: SubjectiveAnswers;
+  livenessVideoRef?: string;
+}
+
+let draft: SessionDraft | null = null;
+
+function uuid(): string {
+  // RFC 4122 v4 — crypto on the JS runtime (Hermes) provides getRandomValues.
+  const bytes = new Uint8Array(16);
+  // @ts-expect-error — Hermes exposes global crypto.
+  globalThis.crypto.getRandomValues(bytes);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex
+    .slice(6, 8)
+    .join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+}
+
+export function startDraft(): SessionDraft {
+  draft = {
+    sessionId: uuid(),
+    startedAt: new Date().toISOString(),
+    blocks: [],
+  };
+  return draft;
+}
+
+export function getDraft(): SessionDraft {
+  if (!draft) return startDraft();
+  return draft;
+}
+
+export function addBlockResult(block: BlockResult): void {
+  const d = getDraft();
+  d.blocks = d.blocks.filter((b) => b.block !== block.block).concat(block);
+}
+
+export function setSubjective(subjective: SubjectiveAnswers): void {
+  getDraft().subjective = subjective;
+}
+
+export function setLivenessRef(ref: string): void {
+  getDraft().livenessVideoRef = ref;
+}
+
+export function clearDraft(): void {
+  draft = null;
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
+}

--- a/docs/antifraud-controls.md
+++ b/docs/antifraud-controls.md
@@ -1,0 +1,89 @@
+# Matriz de Controles Antifraude
+
+Objetivo: impedir que um motorista contorne o teste fazendo com que outra
+pessoa o realize, ou automatize respostas. Inspirado no método do Detran para
+validação de cursos EAD de reciclagem (captura facial + match contra base CNH
++ reverificação periódica + score mínimo de similaridade para aprovação
+automática).
+
+## Quadro-resumo
+
+| Vetor de ataque | Controle | Camada | Severidade |
+|---|---|---|---|
+| Motorista passa o celular pra outra pessoa | Liveness ativo + match CNH no onboarding + reverificação silenciosa | Mobile + SaaS | Crítica |
+| Foto estática na frente da câmera | Liveness ativo (piscar / mover cabeça) certificado iBeta L2 | SaaS | Crítica |
+| Vídeo pré-gravado | Prompts aleatórios na sessão + checagem de frescor (fresh random nonce no prompt) | Mobile | Crítica |
+| Deepfake em tempo real | Provider certificado (Unico/Idwall) com detecção de depth/IR em devices compatíveis; fallback para análise de textura e motion | SaaS | Alta |
+| Emulador / bot tapping | Detecção de emulador (SafetyNet / Play Integrity / DeviceCheck) + entropia de toque (pressão, área, variação angular) | Mobile | Alta |
+| Reprodução do app em desktop com Frida | Attestation de integridade do APK + cert pinning + obfuscação | Mobile | Média |
+| 1 motorista testa de 2 celulares | Device binding: 1 motorista ↔ 1 device; troca exige nova aprovação | Backend | Alta |
+| Teste feito fora do ponto de partida | Geofence por empresa (lat/lng + raio) validada no backend | Backend | Média |
+| Resposta fora do aparelho (console wireshark/replay) | Assinatura HMAC da submissão + nonce de sessão | Backend | Alta |
+| Tampering do registro (ex.: gestor editar resultado) | audit_log append-only + hash de integridade da sessão | DB | Crítica |
+| Tentativa de burlar por retry | Máx 1 retry após amarelo, 10 min cooldown, vermelho bloqueia retry | Backend | Média |
+
+## Detalhes por controle
+
+### 1) Match facial CNH (onboarding)
+
+- Provider: Unico Check (ou Idwall / Serpro Datavalid).
+- Threshold automático: **≥ 90 %** aprova; 80–89 % vai para análise manual
+  pelo gestor; <80 % rejeita.
+- Falha aberta: se o provider estiver indisponível por mais de 1 h, o
+  motorista **não** é liberado — não tentamos bypass local.
+
+### 2) Liveness ativo (pré-teste)
+
+- Sequência aleatória de 2–3 prompts (piscar, virar a cabeça, sorrir).
+- Timeouts agressivos: 8 s para completar a sequência.
+- Rejeitar se o provider retornar score < 0.85.
+
+### 3) Reverificação silenciosa durante o teste
+
+- A cada 15 s do teste cognitivo a câmera frontal captura 1 frame.
+- O frame é enviado ao provider (async, fire-and-forget).
+- Se 2 frames consecutivos retornarem < 0.75 → sessão marcada
+  `fraud_suspect` e invalidada (não gera score).
+- Frames são **descartados** após a conferência; não persistimos.
+
+### 4) Device binding
+
+- Primeiro login após match facial: `device_fingerprint` (hash SHA-256 de
+  install id + model + OS) vira o device autorizado.
+- Login de outro device exige revalidação biométrica + aprovação do gestor.
+- Cooldown de 30 dias para rotação não-supervisionada.
+
+### 5) Geofence
+
+- `companies.geofence` define `{ lat, lng, radius_m }` (ou polygonos futuros).
+- Edge function rejeita submissões com `inside_geofence = false` quando a
+  política da empresa exige. O painel sinaliza a exceção.
+
+### 6) Integridade do dispositivo
+
+- Android: Google Play Integrity API (`device`, `basic` e `strong`).
+- iOS: DeviceCheck + App Attest.
+- Sessão iniciada em device comprometido (emulador, root/jailbreak) é
+  automaticamente marcada `fraud_suspect` — o teste não roda.
+
+### 7) Audit log imutável
+
+- Trigger `log_session_mutation` grava toda mudança em `sessions`.
+- Hash SHA-256 do registro final armazenado em `sessions.integrity_hash` e
+  duplicado no log — qualquer edição divergente é detectada.
+- `revoke update, delete on audit_log from public` impede edição via RLS.
+
+### 8) HMAC e assinatura
+
+- Webhook do provider assinado com `BIOMETRIC_WEBHOOK_SECRET` (HMAC-SHA256).
+- Submissões mobile ganham um `sessionNonce` emitido pelo backend no início
+  da sessão — evita replay.
+
+## Métricas a monitorar (dashboards)
+
+- Taxa de `fraud_suspect` por empresa e por motorista.
+- Distribuição de similaridade de reverificação (alerta se > 5 % abaixo de
+  0.75 no dia).
+- Rotação de device > 1 por motorista/mês.
+- Overrides de bloqueio pelo gestor (obrigatório justificativa).
+- Latência p95 do provider biométrico.

--- a/docs/lgpd-dpia.md
+++ b/docs/lgpd-dpia.md
@@ -1,0 +1,109 @@
+# DPIA — Relatório de Impacto à Proteção de Dados
+
+> Este é um **rascunho técnico** do DPIA exigido pela LGPD (art. 38). Antes de
+> produção, precisa passar por revisão jurídica e pelo Encarregado (DPO) da
+> controladora.
+
+## 1. Identificação do tratamento
+
+- **Sistema:** App Motoristas — avaliação de prontidão cognitiva pré-jornada.
+- **Controladora:** a transportadora (empregadora) contratante.
+- **Operadora:** fornecedora da plataforma (nós).
+- **Sub-operadores:** Supabase (hospedagem BR/EUA), provedor de biometria
+  (Unico / Idwall / Serpro), AWS (storage dos vídeos de liveness).
+
+## 2. Finalidade e base legal
+
+- **Finalidade:** aferir objetiva e subjetivamente a prontidão cognitiva do
+  motorista antes do início da jornada, compondo o sistema de gestão de SST
+  (art. 157 CLT) e reduzindo risco operacional.
+- **Base legal:**
+  - Art. 11, II, "a" LGPD — cumprimento de obrigação legal pela controladora
+    (NR-17 / NR-1 / gestão de riscos ocupacionais).
+  - Art. 7º, V e IX — execução de contrato de trabalho e legítimo interesse
+    do empregador, com balanceamento.
+  - **Consentimento específico e destacado** no primeiro acesso, com opção
+    real de negar (em caso de negativa, a empresa decide alocar o motorista
+    em função compatível sem teste — a negativa não pode ser retaliada).
+
+## 3. Dados tratados (inventário)
+
+| Dado | Categoria | Sensível? | Armazenamento |
+|---|---|---|---|
+| Nome, CPF, CNH, telefone | Pessoal comum | Não | `drivers` (Postgres) |
+| Foto da CNH (referência) | Pessoal comum | Não | Storage privado + provider |
+| Resultado match facial (score numérico) | Pessoal comum | **Sim** (biometria como processo) | `drivers.unico_match_score` |
+| Vídeo de liveness | Biometria | **Sim** | Storage privado, TTL 90d |
+| Tempo de reação, lapsos, CV | Saúde (prontidão) | **Sim** | `cognitive_results` |
+| KSS / Samn-Perelli | Saúde (sono/fadiga) | **Sim** | `subjective_results` |
+| Score final + semáforo | Saúde (inferência) | **Sim** | `session_scores` |
+| Geolocalização no teste | Pessoal comum | Não | `sessions` |
+| Device fingerprint (hash) | Pessoal comum | Não | `sessions` |
+
+## 4. Ciclo de vida e retenção
+
+- **Sessão bruta** (cognitive_results + subjective_results + session_scores):
+  5 anos (prazo de guarda de registros de SST).
+- **Vídeo de liveness:** 90 dias após a sessão — prazo suficiente para
+  responder contestação do motorista e auditoria do sistema antifraude.
+- **Foto da CNH:** somente a referência (ID) fica conosco; a imagem em si
+  permanece com o provider de biometria conforme contrato dele.
+- **Audit log:** 10 anos (art. 68 Código Civil — documentação hábil).
+- **Após baixa do motorista:** dados pessoais são pseudonimizados em até
+  30 dias; audit_log é preservado conforme prazo acima.
+
+## 5. Fluxo de dados
+
+```
+Motorista (app)
+  │  consentimento + foto CNH
+  ▼
+Provider biometria  ──score──▶  Backend (edge function unico-webhook)
+                                      │
+Motorista (app)  ──submissão──▶  Edge function compute-session-score
+                                      │ score
+                                      ▼
+                                 Postgres (RLS por company_id)
+                                      │
+                                      ▼
+                            Dashboard gestor (Next.js)
+```
+
+## 6. Direitos do titular (art. 18 LGPD)
+
+Todos os direitos implementados:
+
+| Direito | Como é atendido |
+|---|---|
+| Confirmação de tratamento | Tela "Meus dados" no app + canal de contato do DPO |
+| Acesso | Endpoint `/drivers/{id}/export` no dashboard (JSON assinado) |
+| Correção | O motorista pode corrigir nome/telefone/CNH no app; dados objetivos do teste não — é registro clínico-legal |
+| Anonimização / bloqueio | Se o motorista sair da empresa, pseudonimização automática após 30d |
+| Portabilidade | Mesmo endpoint de acesso, em JSON estruturado |
+| Eliminação | Só após fim do prazo legal de retenção (5 anos). Até lá, pseudonimizamos. |
+| Revogação de consentimento | Motorista pode revogar; consequência: não poderá mais realizar teste (e a empresa decide a alocação) |
+
+## 7. Riscos e mitigações
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|---|---|---|---|
+| Vazamento de vídeo de liveness | Baixa | Alto | Bucket privado, presigned URL curta, criptografia em repouso, TTL 90d |
+| Vazamento de score de saúde | Baixa | Alto | RLS obrigatório por company_id, service role só em edge functions |
+| Falso positivo biométrico bloqueia motorista legítimo | Média | Médio | Revisão manual <90% de similaridade + contato humano |
+| Discriminação por score reiterado | Média | Alto | Contrato proíbe uso exclusivo do score para decisão de desligamento; sempre revisão humana |
+| Motorista coagido a aceitar consentimento | Alta | Alto | Consentimento separado, reversível; via paralela sem teste documentada |
+| Transferência internacional (Supabase EUA) | Média | Médio | Cláusulas padrão LGPD no contrato; região `sa-east-1` sempre que possível |
+
+## 8. Decisões automatizadas (art. 20)
+
+O score **não** é decisão totalmente automatizada: a "blockagem" é uma
+*recomendação operacional*. A liberação final é da empresa/supervisor, que
+tem o dever de registrar o motivo em caso de override. O motorista tem
+direito a solicitar revisão por pessoa natural — canal no app.
+
+## 9. Pontos abertos para revisão jurídica
+
+- [ ] Modelo de contrato com o provider de biometria (operadora × sub-operadora)
+- [ ] Texto de consentimento com revisão da comunicação
+- [ ] Política específica para motoristas de aplicativo (quando sair do B2B)
+- [ ] Acordo coletivo / sindical, onde aplicável

--- a/docs/scoring-methodology.md
+++ b/docs/scoring-methodology.md
@@ -1,0 +1,152 @@
+# Metodologia de Scoring
+
+Este documento detalha como o `packages/scoring` transforma uma sessão crua
+(blocos cognitivos + questionário) em um semáforo de prontidão operacional.
+
+## Visão geral
+
+```
+        PVT-B raw            KSS + Samn-Perelli
+           │                          │
+           ▼                          ▼
+    métricas por bloco        normalização 0-100
+  (median, lapse, CV RT)             │
+           │                          │
+        Z-score contra norma          │
+           │                          │
+           ▼                          ▼
+       objective (0-100)       subjective (0-100)
+               \        /
+                \      /
+                 combine 60/40
+                     │
+                     ▼
+               finalScore (0-100)
+                     │
+              cutoffs + hard-red rules
+                     │
+                     ▼
+              traffic_light (🟢🟡🔴)
+```
+
+## 1. Bloco PVT-B (Psychomotor Vigilance Test — Brief)
+
+Referência: Basner M, Dinges DF. "Validity and Sensitivity of a Brief PVT
+(PVT-B) to Total and Partial Sleep Deprivation." Acta Astronautica 69 (2011).
+
+### Métricas
+
+- **Mediana do RT (ms):** mediana de todas as respostas válidas.
+- **Lapse rate:** fração de respostas > 500 ms (ou miss).
+- **CV RT:** coeficiente de variação (σ/μ) dos RTs válidos.
+- **False start rate:** taps antes do estímulo / total.
+
+### Normalização (Z-score)
+
+Cada métrica é convertida em Z contra a população de referência:
+
+| Métrica | μ | σ | Fonte |
+|---|---|---|---|
+| Mediana RT | 280 ms | 45 ms | PVT-B literatura (ajustar com dados BR) |
+| Lapse rate | 0.05 | 0.04 | idem |
+| CV RT | 0.18 | 0.05 | idem |
+
+O Z é **negado** antes de agregar (latência/lapsos maiores = pior), então
+Z positivo ⇒ melhor performance.
+
+### Escala para score 0-100
+
+```
+score_bloco = clamp(50 + z * 25, 0, 100)
+```
+
+Onde `z` é a média dos três Zs (RT, lapsos, CV) do bloco.
+
+### Blocos múltiplos
+
+Quando há mais de um bloco, `objective_score` é a média aritmética dos
+`score_bloco`.
+
+## 2. Questionário subjetivo
+
+### KSS (Karolinska Sleepiness Scale, 1-9)
+
+1 = extremamente alerta … 9 = extremamente sonolento.
+Normaliza para `kss_norm = 1 - (kss - 1) / 8` (maior é melhor).
+
+### Samn-Perelli Fatigue (1-7)
+
+1 = totalmente alerta … 7 = completamente exausto.
+Normaliza para `sp_norm = 1 - (sp - 1) / 6`.
+
+### Agregação
+
+```
+subjective_score = ((kss_norm + sp_norm) / 2) * 100
+```
+
+## 3. Score combinado
+
+```
+final_score = 0.6 * objective_score + 0.4 * subjective_score
+```
+
+Peso maior no objetivo para reduzir vieses de auto-reporte; peso subjetivo
+existe porque o próprio motorista é a melhor fonte de sinal quando o PVT
+não capta sono parcial crônico.
+
+## 4. Cutoffs do semáforo
+
+| Semáforo | Critério |
+|---|---|
+| 🟢 Verde | final ≥ 75 e sem hard-red |
+| 🟡 Amarelo | 55 ≤ final < 75 e sem hard-red |
+| 🔴 Vermelho | final < 55 **ou** hard-red acionado |
+
+## 5. Regras hard-red (independem do score)
+
+| Regra | Limiar |
+|---|---|
+| Taxa de lapsos | > 20 % em qualquer bloco |
+| KSS | ≥ 8 |
+| Samn-Perelli | ≥ 6 |
+
+Essas regras existem porque a literatura mostra que motoristas com >20 %
+lapsos em PVT têm risco de acidente comparável a >0.08 % de alcoolemia
+(Dawson & Reid, Nature 1997).
+
+## 6. Política da empresa
+
+O score **descreve** prontidão; a empresa **decide** consequência via
+`companies.block_policy`:
+
+```json
+{ "yellow": "warn", "red": "block" }  // default
+{ "yellow": "block", "red": "block" } // regime severo (cargas perigosas)
+{ "yellow": "warn", "red": "warn" }   // piloto / coleta-sombra
+```
+
+## 7. Baseline pessoal (Fase 2 — roadmap)
+
+Após ≥ 7 sessões por motorista, substituímos a norma populacional por um
+**baseline pessoal** (mediana das últimas 20 sessões verdes). Isso reduz
+falsos positivos em motoristas naturalmente lentos e aumenta sensibilidade
+para motoristas naturalmente rápidos que estão degradando.
+
+## 8. Versionamento
+
+Toda saída carrega `algorithmVersion`. Mudança de cutoff, peso ou norma
+incrementa a versão e é registrada na migration + CHANGELOG. O score é
+reprocessado em lote com a nova versão (rodando `persist_session_score` via
+worker) mantendo o score antigo no audit_log.
+
+## 9. Calibração com dados reais
+
+Plano da Fase 1 → Fase 2:
+
+1. **30 dias de coleta-sombra** com política `warn-warn` (app nunca bloqueia).
+2. Distribuição de `median_rt_ms` dos ~4 primeiros turnos do dia = baseline
+   BR; recalcular μ/σ.
+3. Validar contra incidentes reportados (micro-sinistros, quase-acidentes
+   auto-declarados) via correlação bivariada.
+4. Ajustar cutoffs para atingir taxa-alvo de falso vermelho ≤ 5 %.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "app-motoristas",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Prontidão cognitiva pré-jornada para motoristas de frota (B2B).",
+  "packageManager": "pnpm@9.12.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "pnpm -r --filter=./packages/* build",
+    "typecheck": "pnpm -r typecheck",
+    "test": "pnpm -r --filter=./packages/* test",
+    "lint": "pnpm -r lint",
+    "dashboard:dev": "pnpm --filter @app-motoristas/dashboard dev",
+    "mobile:start": "pnpm --filter @app-motoristas/mobile start",
+    "supabase:reset": "supabase db reset"
+  },
+  "devDependencies": {
+    "typescript": "5.6.3",
+    "vitest": "2.1.4",
+    "@types/node": "22.9.0"
+  }
+}

--- a/packages/cognitive-tests/package.json
+++ b/packages/cognitive-tests/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@app-motoristas/cognitive-tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./controllers": {
+      "types": "./src/controllers/index.ts",
+      "import": "./src/controllers/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@app-motoristas/shared-types": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "18.3.12",
+    "react": "18.3.1",
+    "typescript": "5.6.3",
+    "vitest": "2.1.4"
+  }
+}

--- a/packages/cognitive-tests/src/controllers/index.ts
+++ b/packages/cognitive-tests/src/controllers/index.ts
@@ -1,0 +1,1 @@
+export * from './pvt-b.js';

--- a/packages/cognitive-tests/src/controllers/pvt-b.test.ts
+++ b/packages/cognitive-tests/src/controllers/pvt-b.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPvtController, type PvtEvent } from './pvt-b.js';
+
+const baseConfig = {
+  block: 'pvt_b' as const,
+  totalDurationMs: 5_000,
+  minIsiMs: 1_000,
+  maxIsiMs: 2_000,
+  stimulusTimeoutMs: 800,
+  lapseThresholdMs: 500,
+  falseStartWindowMs: 100,
+  randomSeed: 42,
+};
+
+// Advance tick clock until first stimulus appears, then return timestamp.
+function runUntilStimulus(
+  c: ReturnType<typeof createPvtController>,
+  events: PvtEvent[],
+  maxMs = 4_000,
+): number {
+  for (let t = 0; t < maxMs; t += 16) {
+    c.tick(t);
+    const stim = events.find((e) => e.type === 'stimulus');
+    if (stim) return (stim as Extract<PvtEvent, { type: 'stimulus' }>).shownAtMs;
+  }
+  throw new Error('no stimulus within maxMs');
+}
+
+describe('PVT controller', () => {
+  it('emits stimulus, classifies a fast tap as a valid trial', () => {
+    const c = createPvtController(baseConfig);
+    const events: PvtEvent[] = [];
+    c.subscribe((e) => events.push(e));
+
+    c.start(0);
+    const shownAt = runUntilStimulus(c, events);
+
+    c.onTap(shownAt + 250);
+    const response = events.find((e) => e.type === 'response');
+    expect(response).toBeDefined();
+    const trial = (response as Extract<PvtEvent, { type: 'response' }>).trial;
+    expect(trial.rtMs).toBe(250);
+    expect(trial.isLapse).toBe(false);
+    expect(trial.isFalseStart).toBe(false);
+  });
+
+  it('flags slow response as a lapse', () => {
+    const c = createPvtController(baseConfig);
+    const events: PvtEvent[] = [];
+    c.subscribe((e) => events.push(e));
+
+    c.start(0);
+    const shownAt = runUntilStimulus(c, events);
+
+    c.onTap(shownAt + 600);
+    const response = events.find((e) => e.type === 'response');
+    expect(response).toBeDefined();
+    const trial = (response as Extract<PvtEvent, { type: 'response' }>).trial;
+    expect(trial.isLapse).toBe(true);
+  });
+
+  it('records a miss when stimulus timeout elapses without response', () => {
+    const c = createPvtController(baseConfig);
+    const events: PvtEvent[] = [];
+    c.subscribe((e) => events.push(e));
+
+    c.start(0);
+    for (let t = 0; t < 4_500; t += 16) c.tick(t);
+    expect(events.some((e) => e.type === 'miss')).toBe(true);
+  });
+
+  it('classifies tap before stimulus as false start', () => {
+    const c = createPvtController(baseConfig);
+    const events: PvtEvent[] = [];
+    c.subscribe((e) => events.push(e));
+
+    c.start(0);
+    c.tick(100); // awaiting first stimulus
+    c.onTap(500); // definitely before stimulus (min ISI = 1000)
+    expect(events.some((e) => e.type === 'false_start')).toBe(true);
+  });
+
+  it('finishes at totalDurationMs and emits complete event', () => {
+    const c = createPvtController(baseConfig);
+    const complete = vi.fn();
+    c.subscribe((e) => {
+      if (e.type === 'complete') complete(e.result);
+    });
+
+    c.start(0);
+    for (let t = 0; t < 6_000; t += 16) c.tick(t);
+    expect(complete).toHaveBeenCalledOnce();
+    const result = complete.mock.calls[0]![0];
+    expect(result.block).toBe('pvt_b');
+    expect(result.trials.length).toBeGreaterThan(0);
+    expect(c.isRunning()).toBe(false);
+  });
+
+  it('is deterministic with a fixed seed', () => {
+    const runA = runAndCollect();
+    const runB = runAndCollect();
+    expect(runA).toEqual(runB);
+  });
+});
+
+function runAndCollect(): number[] {
+  const c = createPvtController({ ...baseConfig, randomSeed: 123 });
+  const stimuli: number[] = [];
+  c.subscribe((e) => {
+    if (e.type === 'stimulus') stimuli.push(e.shownAtMs);
+  });
+  c.start(0);
+  for (let t = 0; t < 6_000; t += 16) c.tick(t);
+  return stimuli;
+}

--- a/packages/cognitive-tests/src/controllers/pvt-b.ts
+++ b/packages/cognitive-tests/src/controllers/pvt-b.ts
@@ -1,0 +1,189 @@
+import type { BlockResult, TestBlock, Trial } from '@app-motoristas/shared-types';
+
+// PVT-B controller: framework-agnostic state machine for a brief PVT.
+// The UI layer (mobile or web) calls `tick(nowMs)` on every animation frame,
+// `onTap(nowMs)` on every user response, and receives events via listener.
+// Timing precision: callers should pass monotonic timestamps (performance.now()
+// or reanimated worklet timestamps). We never read the clock internally.
+
+export interface PvtConfig {
+  block: TestBlock; // supports pvt_b, vigilance, etc.
+  totalDurationMs: number; // e.g. 30_000
+  minIsiMs: number; // inter-stimulus interval min (2_000)
+  maxIsiMs: number; // inter-stimulus interval max (6_000)
+  stimulusTimeoutMs: number; // classify as miss after this (e.g. 1_500)
+  lapseThresholdMs: number; // RT > this = lapse (500)
+  falseStartWindowMs: number; // tap before stimulus = false start (within 100ms after prev response)
+  randomSeed?: number;
+}
+
+export type PvtEvent =
+  | { type: 'awaiting'; nextStimulusAtMs: number }
+  | { type: 'stimulus'; shownAtMs: number }
+  | { type: 'response'; trial: Trial }
+  | { type: 'miss'; trial: Trial }
+  | { type: 'false_start'; trial: Trial }
+  | { type: 'complete'; result: BlockResult };
+
+export interface PvtController {
+  start(nowMs: number): void;
+  tick(nowMs: number): void;
+  onTap(nowMs: number): void;
+  subscribe(listener: (event: PvtEvent) => void): () => void;
+  isRunning(): boolean;
+  isStimulusVisible(): boolean;
+  getPartialResult(): BlockResult;
+}
+
+export function createPvtController(config: PvtConfig): PvtController {
+  const listeners = new Set<(e: PvtEvent) => void>();
+  const random = mulberry32(config.randomSeed ?? Date.now() >>> 0);
+
+  let running = false;
+  let startedAtMs = 0;
+  let startedAtIso = '';
+  let nextStimulusAtMs = 0;
+  let stimulusShownAtMs: number | null = null;
+  let lastResponseAtMs = 0;
+  const trials: Trial[] = [];
+
+  function emit(event: PvtEvent): void {
+    for (const l of listeners) l(event);
+  }
+
+  function scheduleNext(nowMs: number): void {
+    const isi = config.minIsiMs + random() * (config.maxIsiMs - config.minIsiMs);
+    nextStimulusAtMs = nowMs + isi;
+    stimulusShownAtMs = null;
+    emit({ type: 'awaiting', nextStimulusAtMs });
+  }
+
+  function finish(nowMs: number): void {
+    running = false;
+    const result: BlockResult = {
+      block: config.block,
+      startedAt: startedAtIso,
+      endedAt: new Date(Date.now() - (nowMs - startedAtMs) + (nowMs - startedAtMs)).toISOString(),
+      trials: [...trials],
+    };
+    emit({ type: 'complete', result });
+  }
+
+  return {
+    start(nowMs) {
+      running = true;
+      startedAtMs = nowMs;
+      startedAtIso = new Date().toISOString();
+      trials.length = 0;
+      lastResponseAtMs = nowMs;
+      scheduleNext(nowMs);
+    },
+
+    tick(nowMs) {
+      if (!running) return;
+      if (nowMs - startedAtMs >= config.totalDurationMs) {
+        if (stimulusShownAtMs != null) {
+          const trial: Trial = {
+            stimulusAtMs: stimulusShownAtMs,
+            responseAtMs: null,
+            rtMs: null,
+            isLapse: true,
+            isFalseStart: false,
+          };
+          trials.push(trial);
+          emit({ type: 'miss', trial });
+        }
+        finish(nowMs);
+        return;
+      }
+      if (stimulusShownAtMs == null && nowMs >= nextStimulusAtMs) {
+        stimulusShownAtMs = nowMs;
+        emit({ type: 'stimulus', shownAtMs: nowMs });
+        return;
+      }
+      if (stimulusShownAtMs != null && nowMs - stimulusShownAtMs >= config.stimulusTimeoutMs) {
+        const trial: Trial = {
+          stimulusAtMs: stimulusShownAtMs,
+          responseAtMs: null,
+          rtMs: null,
+          isLapse: true,
+          isFalseStart: false,
+        };
+        trials.push(trial);
+        emit({ type: 'miss', trial });
+        lastResponseAtMs = nowMs;
+        scheduleNext(nowMs);
+      }
+    },
+
+    onTap(nowMs) {
+      if (!running) return;
+      if (stimulusShownAtMs == null) {
+        // Tapped before stimulus — false start.
+        if (nowMs - lastResponseAtMs < config.falseStartWindowMs) {
+          // Ignore double-taps within debounce window.
+          return;
+        }
+        const trial: Trial = {
+          stimulusAtMs: nextStimulusAtMs,
+          responseAtMs: nowMs,
+          rtMs: null,
+          isLapse: false,
+          isFalseStart: true,
+        };
+        trials.push(trial);
+        emit({ type: 'false_start', trial });
+        lastResponseAtMs = nowMs;
+        scheduleNext(nowMs);
+        return;
+      }
+      const rt = nowMs - stimulusShownAtMs;
+      const trial: Trial = {
+        stimulusAtMs: stimulusShownAtMs,
+        responseAtMs: nowMs,
+        rtMs: rt,
+        isLapse: rt > config.lapseThresholdMs,
+        isFalseStart: false,
+      };
+      trials.push(trial);
+      emit({ type: 'response', trial });
+      lastResponseAtMs = nowMs;
+      scheduleNext(nowMs);
+    },
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+
+    isRunning() {
+      return running;
+    },
+
+    isStimulusVisible() {
+      return stimulusShownAtMs != null;
+    },
+
+    getPartialResult() {
+      return {
+        block: config.block,
+        startedAt: startedAtIso,
+        endedAt: new Date().toISOString(),
+        trials: [...trials],
+      };
+    },
+  };
+}
+
+// Tiny deterministic PRNG so tests are reproducible.
+// Source: https://stackoverflow.com/a/47593316 (public domain).
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/packages/cognitive-tests/src/index.ts
+++ b/packages/cognitive-tests/src/index.ts
@@ -1,0 +1,1 @@
+export * from './controllers/index.js';

--- a/packages/cognitive-tests/tsconfig.json
+++ b/packages/cognitive-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src"]
+}

--- a/packages/scoring/package.json
+++ b/packages/scoring/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@app-motoristas/scoring",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@app-motoristas/shared-types": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "5.6.3",
+    "vitest": "2.1.4"
+  }
+}

--- a/packages/scoring/src/index.ts
+++ b/packages/scoring/src/index.ts
@@ -1,0 +1,9 @@
+export * from './scorer.js';
+export * from './stats.js';
+export {
+  ALGORITHM_VERSION,
+  HARD_RED_RULES,
+  PVT_B_NORMS,
+  SCORE_WEIGHTS,
+  TRAFFIC_LIGHT_CUTOFFS,
+} from './norms.js';

--- a/packages/scoring/src/norms.ts
+++ b/packages/scoring/src/norms.ts
@@ -1,0 +1,31 @@
+// Valores de normalização populacional para PVT-B (3 min) em motoristas adultos.
+// Fonte: Basner M. et al., "Validity and Sensitivity of a Brief PVT (PVT-B)",
+// Acta Astronautica 69 (2011) + literatura adicional para contexto mobile.
+// Estes são defaults do MVP — serão recalibrados com dados próprios após
+// coleta-sombra de 30 dias (ver plan.md: "Cutoffs PVT sem validação BR").
+export const PVT_B_NORMS = {
+  medianRtMs: { mean: 280, sd: 45 },
+  lapseRate: { mean: 0.05, sd: 0.04 }, // fração de respostas > 500ms
+  cvRt: { mean: 0.18, sd: 0.05 }, // coeficiente de variação
+} as const;
+
+// Limiares do semáforo para o score final (0-100).
+export const TRAFFIC_LIGHT_CUTOFFS = {
+  greenMin: 75,
+  yellowMin: 55,
+} as const;
+
+// Limites duros que forçam vermelho independente do score combinado.
+export const HARD_RED_RULES = {
+  lapseRateThreshold: 0.2, // >20% de lapsos
+  kssThreshold: 8, // KSS >= 8 = muito sonolento
+  samnPerelliThreshold: 6, // 6 = extremely tired / 7 = completely exhausted
+} as const;
+
+// Pesos do score combinado.
+export const SCORE_WEIGHTS = {
+  objective: 0.6,
+  subjective: 0.4,
+} as const;
+
+export const ALGORITHM_VERSION = 'v1';

--- a/packages/scoring/src/scorer.test.ts
+++ b/packages/scoring/src/scorer.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import type { BlockResult, SessionSubmission, Trial } from '@app-motoristas/shared-types';
+import { scoreSession } from './scorer.js';
+
+function makeTrial(rtMs: number | null, opts: Partial<Trial> = {}): Trial {
+  return {
+    stimulusAtMs: 0,
+    responseAtMs: rtMs == null ? null : rtMs,
+    rtMs,
+    isLapse: rtMs != null && rtMs > 500,
+    isFalseStart: false,
+    ...opts,
+  };
+}
+
+function makeBlock(rts: (number | null)[], block: BlockResult['block'] = 'pvt_b'): BlockResult {
+  return {
+    block,
+    startedAt: '2026-04-19T12:00:00.000Z',
+    endedAt: '2026-04-19T12:00:30.000Z',
+    trials: rts.map((rt) => makeTrial(rt)),
+  };
+}
+
+function makeSubmission(overrides: Partial<SessionSubmission> = {}): SessionSubmission {
+  return {
+    sessionId: '00000000-0000-0000-0000-000000000001',
+    driverId: '00000000-0000-0000-0000-000000000002',
+    startedAt: '2026-04-19T12:00:00.000Z',
+    completedAt: '2026-04-19T12:01:15.000Z',
+    deviceFingerprint: 'device-abc123',
+    appVersion: '0.1.0',
+    geo: { lat: -23.55, lng: -46.63 },
+    livenessVideoRef: 'liveness-videos/session-1.mp4',
+    livenessMatchScore: 97,
+    blocks: [makeBlock([250, 260, 270, 280, 290, 300])],
+    subjective: { kss: 3, samnPerelli: 2, hoursSlept: 8 },
+    ...overrides,
+  };
+}
+
+const permissivePolicy = { yellow: 'warn', red: 'warn' } as const;
+const strictPolicy = { yellow: 'warn', red: 'block' } as const;
+
+describe('scoreSession — happy path (green)', () => {
+  it('gives green for fast, consistent RTs and alert subjective state', () => {
+    const out = scoreSession({ submission: makeSubmission(), policy: strictPolicy });
+    expect(out.trafficLight).toBe('green');
+    expect(out.blocked).toBe(false);
+    expect(out.hardRedReasons).toEqual([]);
+    expect(out.finalScore).toBeGreaterThanOrEqual(75);
+  });
+});
+
+describe('scoreSession — yellow (moderate)', () => {
+  it('returns yellow when RTs are mediocre and subjective is borderline', () => {
+    const out = scoreSession({
+      submission: makeSubmission({
+        blocks: [makeBlock([330, 340, 355, 360, 380, 370])],
+        subjective: { kss: 6, samnPerelli: 4 },
+      }),
+      policy: strictPolicy,
+    });
+    expect(out.trafficLight).toBe('yellow');
+    expect(out.blocked).toBe(false);
+  });
+
+  it('blocks yellow when policy sets yellow: block', () => {
+    const out = scoreSession({
+      submission: makeSubmission({
+        blocks: [makeBlock([330, 340, 355, 360, 380, 370])],
+        subjective: { kss: 6, samnPerelli: 4 },
+      }),
+      policy: { yellow: 'block', red: 'block' },
+    });
+    expect(out.trafficLight).toBe('yellow');
+    expect(out.blocked).toBe(true);
+  });
+});
+
+describe('scoreSession — red (low score, soft)', () => {
+  it('returns red when combined score falls below yellow cutoff', () => {
+    const out = scoreSession({
+      submission: makeSubmission({
+        blocks: [makeBlock([420, 450, 470, 490, 480, 460])],
+        subjective: { kss: 7, samnPerelli: 5 },
+      }),
+      policy: strictPolicy,
+    });
+    expect(out.trafficLight).toBe('red');
+    expect(out.blocked).toBe(true);
+  });
+});
+
+describe('scoreSession — hard red by lapses', () => {
+  it('forces red when lapse rate > 20 percent even if score would be yellow', () => {
+    // 4/10 lapses = 40% — way above 20% threshold.
+    const rts = [250, 260, 270, 280, 290, 300, 520, 540, 560, 600];
+    const out = scoreSession({
+      submission: makeSubmission({
+        blocks: [makeBlock(rts)],
+        subjective: { kss: 2, samnPerelli: 2 },
+      }),
+      policy: strictPolicy,
+    });
+    expect(out.trafficLight).toBe('red');
+    expect(out.blocked).toBe(true);
+    expect(out.hardRedReasons.some((r) => r.startsWith('lapse_rate_exceeded'))).toBe(true);
+  });
+});
+
+describe('scoreSession — hard red by KSS', () => {
+  it('forces red when KSS >= 8 regardless of fast RTs', () => {
+    const out = scoreSession({
+      submission: makeSubmission({
+        blocks: [makeBlock([220, 230, 240, 250])],
+        subjective: { kss: 9, samnPerelli: 3 },
+      }),
+      policy: strictPolicy,
+    });
+    expect(out.trafficLight).toBe('red');
+    expect(out.hardRedReasons).toContain('kss_critical:9');
+  });
+});
+
+describe('scoreSession — hard red by Samn-Perelli', () => {
+  it('forces red when Samn-Perelli >= 6', () => {
+    const out = scoreSession({
+      submission: makeSubmission({
+        blocks: [makeBlock([220, 230, 240, 250])],
+        subjective: { kss: 4, samnPerelli: 7 },
+      }),
+      policy: strictPolicy,
+    });
+    expect(out.trafficLight).toBe('red');
+    expect(out.hardRedReasons).toContain('samn_perelli_critical:7');
+  });
+});
+
+describe('scoreSession — permissive policy never blocks', () => {
+  it('does not set blocked=true when policy is warn-only', () => {
+    const out = scoreSession({
+      submission: makeSubmission({
+        blocks: [makeBlock([420, 450, 470, 490, 480, 460])],
+        subjective: { kss: 7, samnPerelli: 5 },
+      }),
+      policy: permissivePolicy,
+    });
+    expect(out.trafficLight).toBe('red');
+    expect(out.blocked).toBe(false);
+  });
+});
+
+describe('scoreSession — metrics sanity', () => {
+  it('computes median, lapse rate and CV per block', () => {
+    const out = scoreSession({
+      submission: makeSubmission({ blocks: [makeBlock([200, 300, 400, 500, 600])] }),
+      policy: strictPolicy,
+    });
+    const m = out.blockMetrics['pvt_b'];
+    expect(m).toBeDefined();
+    expect(m!.medianRtMs).toBe(400);
+    expect(m!.lapseRate).toBeCloseTo(0.2, 5);
+    expect(m!.cvRt).toBeGreaterThan(0);
+  });
+
+  it('counts false starts without crashing', () => {
+    const block: BlockResult = {
+      block: 'pvt_b',
+      startedAt: '2026-04-19T12:00:00.000Z',
+      endedAt: '2026-04-19T12:00:30.000Z',
+      trials: [
+        makeTrial(250),
+        { stimulusAtMs: 0, responseAtMs: 50, rtMs: null, isLapse: false, isFalseStart: true },
+        makeTrial(280),
+      ],
+    };
+    const out = scoreSession({
+      submission: makeSubmission({ blocks: [block] }),
+      policy: strictPolicy,
+    });
+    expect(out.blockMetrics['pvt_b']!.falseStartRate).toBeCloseTo(1 / 3, 5);
+  });
+});
+
+describe('scoreSession — output contract', () => {
+  it('always includes algorithm version and numeric scores', () => {
+    const out = scoreSession({ submission: makeSubmission(), policy: strictPolicy });
+    expect(out.algorithmVersion).toBe('v1');
+    expect(Number.isFinite(out.objectiveScore)).toBe(true);
+    expect(Number.isFinite(out.subjectiveScore)).toBe(true);
+    expect(Number.isFinite(out.finalScore)).toBe(true);
+    expect(out.finalScore).toBeGreaterThanOrEqual(0);
+    expect(out.finalScore).toBeLessThanOrEqual(100);
+  });
+});

--- a/packages/scoring/src/scorer.ts
+++ b/packages/scoring/src/scorer.ts
@@ -1,0 +1,146 @@
+import type {
+  BlockResult,
+  SessionScore,
+  SessionSubmission,
+  SubjectiveAnswers,
+  TrafficLight,
+  Trial,
+} from '@app-motoristas/shared-types';
+import {
+  ALGORITHM_VERSION,
+  HARD_RED_RULES,
+  PVT_B_NORMS,
+  SCORE_WEIGHTS,
+  TRAFFIC_LIGHT_CUTOFFS,
+} from './norms.js';
+import { coefficientOfVariation, median, zScore, zToScore } from './stats.js';
+
+export interface BlockMetrics {
+  medianRtMs: number;
+  lapseRate: number;
+  cvRt: number;
+  falseStartRate: number;
+  zScore: number;
+}
+
+export interface ScoringInput {
+  submission: SessionSubmission;
+  policy: { yellow: 'warn' | 'block'; red: 'warn' | 'block' };
+}
+
+export interface ScoringOutput extends SessionScore {
+  blockMetrics: Record<string, BlockMetrics>;
+  hardRedReasons: string[];
+}
+
+export function computeBlockMetrics(block: BlockResult): BlockMetrics {
+  const validTrials: Trial[] = block.trials.filter((t) => !t.isFalseStart && t.rtMs != null);
+  const rts = validTrials.map((t) => t.rtMs as number);
+  const falseStarts = block.trials.filter((t) => t.isFalseStart).length;
+
+  const med = rts.length > 0 ? median(rts) : 0;
+  const lapses = validTrials.filter((t) => t.isLapse).length;
+  const lapseRate = validTrials.length > 0 ? lapses / validTrials.length : 0;
+  const cv = rts.length > 1 ? coefficientOfVariation(rts) : 0;
+  const falseStartRate = block.trials.length > 0 ? falseStarts / block.trials.length : 0;
+
+  // Compose a single Z for the block: average across RT, lapses and CV (higher = worse).
+  // Negate so that LOWER RT/lapse → positive Z (better performance).
+  const zs = [
+    -zScore(med, PVT_B_NORMS.medianRtMs),
+    -zScore(lapseRate, PVT_B_NORMS.lapseRate),
+    -zScore(cv, PVT_B_NORMS.cvRt),
+  ];
+  const avgZ = zs.reduce((s, v) => s + v, 0) / zs.length;
+
+  return {
+    medianRtMs: med,
+    lapseRate,
+    cvRt: cv,
+    falseStartRate,
+    zScore: avgZ,
+  };
+}
+
+export function computeObjectiveScore(blocks: BlockResult[]): {
+  score: number;
+  metrics: Record<string, BlockMetrics>;
+} {
+  if (blocks.length === 0) {
+    return { score: 0, metrics: {} };
+  }
+  const metrics: Record<string, BlockMetrics> = {};
+  let zSum = 0;
+  for (const block of blocks) {
+    const m = computeBlockMetrics(block);
+    metrics[block.block] = m;
+    zSum += m.zScore;
+  }
+  const avgZ = zSum / blocks.length;
+  return { score: zToScore(avgZ), metrics };
+}
+
+export function computeSubjectiveScore(answers: SubjectiveAnswers): number {
+  // KSS: 1 (alert) → 9 (very sleepy).  Samn-Perelli: 1 (fully alert) → 7 (exhausted).
+  // Normalize each to 0..1 (where 0 = worst) and average.
+  const kssNorm = 1 - (answers.kss - 1) / 8;
+  const spNorm = 1 - (answers.samnPerelli - 1) / 6;
+  return Math.max(0, Math.min(100, ((kssNorm + spNorm) / 2) * 100));
+}
+
+export function classifyTrafficLight(finalScore: number, hardRed: boolean): TrafficLight {
+  if (hardRed) return 'red';
+  if (finalScore >= TRAFFIC_LIGHT_CUTOFFS.greenMin) return 'green';
+  if (finalScore >= TRAFFIC_LIGHT_CUTOFFS.yellowMin) return 'yellow';
+  return 'red';
+}
+
+export function evaluateHardRed(
+  metrics: Record<string, BlockMetrics>,
+  subjective: SubjectiveAnswers,
+): string[] {
+  const reasons: string[] = [];
+  for (const [block, m] of Object.entries(metrics)) {
+    if (m.lapseRate > HARD_RED_RULES.lapseRateThreshold) {
+      reasons.push(`lapse_rate_exceeded:${block}:${m.lapseRate.toFixed(3)}`);
+    }
+  }
+  if (subjective.kss >= HARD_RED_RULES.kssThreshold) {
+    reasons.push(`kss_critical:${subjective.kss}`);
+  }
+  if (subjective.samnPerelli >= HARD_RED_RULES.samnPerelliThreshold) {
+    reasons.push(`samn_perelli_critical:${subjective.samnPerelli}`);
+  }
+  return reasons;
+}
+
+export function scoreSession(input: ScoringInput): ScoringOutput {
+  const { submission, policy } = input;
+  const { score: objectiveScore, metrics } = computeObjectiveScore(submission.blocks);
+  const subjectiveScore = computeSubjectiveScore(submission.subjective);
+  const finalScore =
+    objectiveScore * SCORE_WEIGHTS.objective + subjectiveScore * SCORE_WEIGHTS.subjective;
+
+  const hardRedReasons = evaluateHardRed(metrics, submission.subjective);
+  const trafficLight = classifyTrafficLight(finalScore, hardRedReasons.length > 0);
+
+  const blocked =
+    (trafficLight === 'red' && policy.red === 'block') ||
+    (trafficLight === 'yellow' && policy.yellow === 'block');
+
+  return {
+    sessionId: submission.sessionId,
+    objectiveScore: round2(objectiveScore),
+    subjectiveScore: round2(subjectiveScore),
+    finalScore: round2(finalScore),
+    trafficLight,
+    blocked,
+    algorithmVersion: ALGORITHM_VERSION,
+    blockMetrics: metrics,
+    hardRedReasons,
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/packages/scoring/src/stats.test.ts
+++ b/packages/scoring/src/stats.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  coefficientOfVariation,
+  mean,
+  median,
+  stdDev,
+  zScore,
+  zToScore,
+} from './stats.js';
+
+describe('stats helpers', () => {
+  it('computes median for odd and even lengths', () => {
+    expect(median([3, 1, 2])).toBe(2);
+    expect(median([4, 1, 2, 3])).toBe(2.5);
+  });
+
+  it('throws on empty input for median/mean', () => {
+    expect(() => median([])).toThrow();
+    expect(() => mean([])).toThrow();
+  });
+
+  it('computes mean and sd', () => {
+    expect(mean([1, 2, 3, 4, 5])).toBe(3);
+    expect(stdDev([1, 2, 3, 4, 5])).toBeCloseTo(1.5811, 3);
+  });
+
+  it('returns 0 sd for single-value input', () => {
+    expect(stdDev([42])).toBe(0);
+  });
+
+  it('computes coefficient of variation and handles zero mean', () => {
+    expect(coefficientOfVariation([100, 110, 120])).toBeCloseTo(stdDev([100, 110, 120]) / 110, 5);
+    expect(coefficientOfVariation([0, 0, 0])).toBe(0);
+  });
+
+  it('z-score correctly normalizes a value', () => {
+    expect(zScore(280, { mean: 280, sd: 45 })).toBe(0);
+    expect(zScore(325, { mean: 280, sd: 45 })).toBe(1);
+    expect(zScore(280, { mean: 280, sd: 0 })).toBe(0);
+  });
+
+  it('zToScore clamps into 0..100', () => {
+    expect(zToScore(0)).toBe(50);
+    expect(zToScore(2)).toBe(100);
+    expect(zToScore(-2)).toBe(0);
+    expect(zToScore(10)).toBe(100);
+    expect(zToScore(-10)).toBe(0);
+  });
+});

--- a/packages/scoring/src/stats.ts
+++ b/packages/scoring/src/stats.ts
@@ -1,0 +1,36 @@
+export function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error('median() requires at least one value');
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+export function mean(values: readonly number[]): number {
+  if (values.length === 0) throw new Error('mean() requires at least one value');
+  return values.reduce((s, v) => s + v, 0) / values.length;
+}
+
+export function stdDev(values: readonly number[]): number {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  const variance = values.reduce((s, v) => s + (v - m) ** 2, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+export function coefficientOfVariation(values: readonly number[]): number {
+  const m = mean(values);
+  if (m === 0) return 0;
+  return stdDev(values) / m;
+}
+
+export function zScore(value: number, norm: { mean: number; sd: number }): number {
+  if (norm.sd === 0) return 0;
+  return (value - norm.mean) / norm.sd;
+}
+
+// Clamp a Z-score into a [0, 100] scale where Z=0 → 50, Z=-2 → 0, Z=+2 → 100.
+// For PVT, higher RT / lapses are WORSE, so the caller negates the Z before passing.
+export function zToScore(z: number): number {
+  const scaled = 50 + z * 25;
+  return Math.max(0, Math.min(100, scaled));
+}

--- a/packages/scoring/tsconfig.json
+++ b/packages/scoring/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@app-motoristas/shared-types",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "5.6.3"
+  }
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+
+export const TrafficLight = z.enum(['green', 'yellow', 'red']);
+export type TrafficLight = z.infer<typeof TrafficLight>;
+
+export const TestBlock = z.enum(['pvt_b', 'divided_attention', 'vigilance']);
+export type TestBlock = z.infer<typeof TestBlock>;
+
+export const SessionStatus = z.enum([
+  'started',
+  'liveness_ok',
+  'in_test',
+  'completed',
+  'aborted',
+  'fraud_suspect',
+]);
+export type SessionStatus = z.infer<typeof SessionStatus>;
+
+export const DriverStatus = z.enum(['pending_match', 'active', 'blocked', 'archived']);
+export type DriverStatus = z.infer<typeof DriverStatus>;
+
+// One stimulus-response trial within a cognitive block.
+export const TrialSchema = z.object({
+  stimulusAtMs: z.number().nonnegative(),
+  responseAtMs: z.number().nonnegative().nullable(),
+  rtMs: z.number().nonnegative().nullable(),
+  isLapse: z.boolean(),
+  isFalseStart: z.boolean(),
+});
+export type Trial = z.infer<typeof TrialSchema>;
+
+export const BlockResultSchema = z.object({
+  block: TestBlock,
+  startedAt: z.string().datetime(),
+  endedAt: z.string().datetime(),
+  trials: z.array(TrialSchema).min(1),
+});
+export type BlockResult = z.infer<typeof BlockResultSchema>;
+
+// Subjective questionnaire (KSS + Samn-Perelli).
+export const SubjectiveAnswersSchema = z.object({
+  kss: z.number().int().min(1).max(9),
+  samnPerelli: z.number().int().min(1).max(7),
+  hoursSlept: z.number().min(0).max(24).optional(),
+});
+export type SubjectiveAnswers = z.infer<typeof SubjectiveAnswersSchema>;
+
+export const GeoPointSchema = z.object({
+  lat: z.number().min(-90).max(90),
+  lng: z.number().min(-180).max(180),
+  accuracyM: z.number().nonnegative().optional(),
+});
+export type GeoPoint = z.infer<typeof GeoPointSchema>;
+
+// Payload uploaded by the mobile app when a session ends.
+export const SessionSubmissionSchema = z.object({
+  sessionId: z.string().uuid(),
+  driverId: z.string().uuid(),
+  startedAt: z.string().datetime(),
+  completedAt: z.string().datetime(),
+  deviceFingerprint: z.string().min(8),
+  appVersion: z.string(),
+  geo: GeoPointSchema.nullable(),
+  livenessVideoRef: z.string().nullable(),
+  livenessMatchScore: z.number().min(0).max(100).nullable(),
+  blocks: z.array(BlockResultSchema).min(1),
+  subjective: SubjectiveAnswersSchema,
+});
+export type SessionSubmission = z.infer<typeof SessionSubmissionSchema>;
+
+export const SessionScoreSchema = z.object({
+  sessionId: z.string().uuid(),
+  objectiveScore: z.number().min(0).max(100),
+  subjectiveScore: z.number().min(0).max(100),
+  finalScore: z.number().min(0).max(100),
+  trafficLight: TrafficLight,
+  blocked: z.boolean(),
+  algorithmVersion: z.string(),
+});
+export type SessionScore = z.infer<typeof SessionScoreSchema>;
+
+export const BlockPolicySchema = z.object({
+  yellow: z.enum(['warn', 'block']).default('warn'),
+  red: z.enum(['warn', 'block']).default('block'),
+});
+export type BlockPolicy = z.infer<typeof BlockPolicySchema>;

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,989 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: 22.9.0
+        version: 22.9.0
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+      vitest:
+        specifier: 2.1.4
+        version: 2.1.4(@types/node@22.9.0)
+
+  packages/cognitive-tests:
+    dependencies:
+      '@app-motoristas/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
+    devDependencies:
+      '@types/react':
+        specifier: 18.3.12
+        version: 18.3.12
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+      vitest:
+        specifier: 2.1.4
+        version: 2.1.4(@types/node@22.9.0)
+
+  packages/scoring:
+    dependencies:
+      '@app-motoristas/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
+    devDependencies:
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+      vitest:
+        specifier: 2.1.4
+        version: 2.1.4(@types/node@22.9.0)
+
+  packages/shared-types:
+    dependencies:
+      zod:
+        specifier: 3.23.8
+        version: 3.23.8
+    devDependencies:
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.9.0':
+    resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react@18.3.12':
+    resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
+
+  '@vitest/expect@2.1.4':
+    resolution: {integrity: sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==}
+
+  '@vitest/mocker@2.1.4':
+    resolution: {integrity: sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.4':
+    resolution: {integrity: sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==}
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.4':
+    resolution: {integrity: sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==}
+
+  '@vitest/snapshot@2.1.4':
+    resolution: {integrity: sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==}
+
+  '@vitest/spy@2.1.4':
+    resolution: {integrity: sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==}
+
+  '@vitest/utils@2.1.4':
+    resolution: {integrity: sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  vite-node@2.1.4:
+    resolution: {integrity: sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.4:
+    resolution: {integrity: sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.4
+      '@vitest/ui': 2.1.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.9.0':
+    dependencies:
+      undici-types: 6.19.8
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react@18.3.12':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@vitest/expect@2.1.4':
+    dependencies:
+      '@vitest/spy': 2.1.4
+      '@vitest/utils': 2.1.4
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.4(vite@5.4.21(@types/node@22.9.0))':
+    dependencies:
+      '@vitest/spy': 2.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.9.0)
+
+  '@vitest/pretty-format@2.1.4':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.4':
+    dependencies:
+      '@vitest/utils': 2.1.4
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.4':
+    dependencies:
+      '@vitest/pretty-format': 2.1.4
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.4':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.4':
+    dependencies:
+      '@vitest/pretty-format': 2.1.4
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  js-tokens@4.0.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  typescript@5.6.3: {}
+
+  undici-types@6.19.8: {}
+
+  vite-node@2.1.4(@types/node@22.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.9.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.9.0
+      fsevents: 2.3.3
+
+  vitest@2.1.4(@types/node@22.9.0):
+    dependencies:
+      '@vitest/expect': 2.1.4
+      '@vitest/mocker': 2.1.4(vite@5.4.21(@types/node@22.9.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.4
+      '@vitest/snapshot': 2.1.4
+      '@vitest/spy': 2.1.4
+      '@vitest/utils': 2.1.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.9.0)
+      vite-node: 2.1.4(@types/node@22.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.9.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zod@3.23.8: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,34 @@
+project_id = "app-motoristas"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public"]
+
+[db]
+port = 54322
+major_version = 15
+
+[studio]
+enabled = true
+port = 54323
+
+[auth]
+enabled = true
+site_url = "http://localhost:3000"
+additional_redirect_urls = ["http://localhost:3000/**"]
+enable_signup = false
+
+[auth.email]
+enable_signup = false
+enable_confirmations = false
+
+[storage]
+enabled = true
+file_size_limit = "50MiB"
+buckets.cnh-photos.public = false
+buckets.liveness-videos.public = false
+
+[edge_runtime]
+enabled = true
+policy = "oneshot"

--- a/supabase/functions/compute-session-score/index.ts
+++ b/supabase/functions/compute-session-score/index.ts
@@ -1,0 +1,109 @@
+// Edge function: receives a SessionSubmission from the mobile app, runs the
+// scoring engine, persists every artefact (session, cognitive_results,
+// subjective_results, session_scores) inside a single RPC-style transaction
+// and returns the SessionScore so the app can render the traffic light.
+//
+// Auth: the function is invoked with the driver's anon JWT — we trust the
+// claim for driver_id, but we re-read the company_id + block_policy from the
+// drivers / companies tables before scoring, so the client cannot spoof them.
+
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.46.1';
+import { z } from 'https://esm.sh/zod@3.23.8';
+import { scoreSession } from 'npm:@app-motoristas/scoring@0.1.0';
+import {
+  SessionSubmissionSchema,
+  BlockPolicySchema,
+} from 'npm:@app-motoristas/shared-types@0.1.0';
+
+// Deno + Supabase function runtime types are provided by the platform.
+// deno-lint-ignore no-explicit-any
+const Deno: any = (globalThis as any).Deno;
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return json({ error: 'method not allowed' }, 405);
+
+  const auth = req.headers.get('authorization');
+  if (!auth) return json({ error: 'missing authorization' }, 401);
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: 'invalid json' }, 400);
+  }
+
+  const parsed = SessionSubmissionSchema.safeParse(body);
+  if (!parsed.success) return json({ error: 'invalid payload', details: parsed.error.issues }, 400);
+  const submission = parsed.data;
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const userJwt = auth.replace(/^Bearer /i, '');
+
+  // 1) Authenticate the driver via their JWT (anon key path).
+  const userClient = createClient(supabaseUrl, Deno.env.get('SUPABASE_ANON_KEY'), {
+    global: { headers: { Authorization: `Bearer ${userJwt}` } },
+  });
+  const { data: userRes, error: userErr } = await userClient.auth.getUser();
+  if (userErr || !userRes.user) return json({ error: 'unauthorized' }, 401);
+  if (userRes.user.id !== submission.driverId)
+    return json({ error: 'driver id mismatch with JWT' }, 403);
+
+  // 2) Service-role client for privileged writes (bypasses RLS — safe here
+  //    because we just verified the driver above).
+  const admin = createClient(supabaseUrl, serviceRoleKey);
+
+  // 3) Resolve driver + company policy.
+  const { data: driver, error: dErr } = await admin
+    .from('drivers')
+    .select('id, company_id, status, companies!inner(block_policy)')
+    .eq('id', submission.driverId)
+    .single();
+  if (dErr || !driver) return json({ error: 'driver not found' }, 404);
+  if (driver.status !== 'active') return json({ error: `driver status ${driver.status}` }, 403);
+
+  const policy = BlockPolicySchema.parse(
+    (driver as { companies: { block_policy: unknown } }).companies.block_policy ?? {},
+  );
+
+  // 4) Score.
+  const output = scoreSession({ submission, policy });
+
+  // 5) Persist in one round-trip via RPC stored on the DB.
+  const { error: rpcErr } = await admin.rpc('persist_session_score', {
+    p_session_id: submission.sessionId,
+    p_driver_id: submission.driverId,
+    p_company_id: driver.company_id,
+    p_payload: submission,
+    p_output: output,
+  });
+  if (rpcErr) return json({ error: 'persist failed', details: rpcErr.message }, 500);
+
+  return json(
+    {
+      sessionId: output.sessionId,
+      objectiveScore: output.objectiveScore,
+      subjectiveScore: output.subjectiveScore,
+      finalScore: output.finalScore,
+      trafficLight: output.trafficLight,
+      blocked: output.blocked,
+      algorithmVersion: output.algorithmVersion,
+    },
+    200,
+  );
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'content-type': 'application/json' },
+  });
+}

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "std/": "https://deno.land/std@0.208.0/"
+  },
+  "lint": { "rules": { "tags": ["recommended"] } },
+  "fmt": { "lineWidth": 100, "singleQuote": true }
+}

--- a/supabase/functions/unico-webhook/index.ts
+++ b/supabase/functions/unico-webhook/index.ts
@@ -1,0 +1,101 @@
+// Webhook handler for the biometric provider (Unico Check / Idwall / Serpro).
+// Called server-to-server when the provider completes an identity verification
+// against the CNH database. On a successful match (>= 90%), we flip the
+// driver status to "active" so they can take tests; otherwise the driver is
+// flagged for manual review in the dashboard.
+//
+// Security:
+//   - Verifies an HMAC-SHA256 signature using BIOMETRIC_WEBHOOK_SECRET.
+//   - Only the service role client is used here (no RLS bypass risk because
+//     the function is gated by the shared secret).
+
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.46.1';
+import { z } from 'https://esm.sh/zod@3.23.8';
+
+// deno-lint-ignore no-explicit-any
+const Deno: any = (globalThis as any).Deno;
+
+const Payload = z.object({
+  driverId: z.string().uuid(),
+  provider: z.enum(['unico', 'idwall', 'serpro']),
+  providerTxId: z.string().min(1),
+  matchScore: z.number().min(0).max(100),
+  verifiedAt: z.string().datetime(),
+  livenessPassed: z.boolean(),
+  reason: z.string().optional(),
+});
+
+const AUTO_APPROVE_THRESHOLD = 90;
+
+serve(async (req) => {
+  if (req.method !== 'POST') return new Response('method not allowed', { status: 405 });
+
+  const raw = await req.text();
+  const signature = req.headers.get('x-webhook-signature');
+  const secret = Deno.env.get('BIOMETRIC_WEBHOOK_SECRET');
+  if (!signature || !secret) return new Response('unauthorized', { status: 401 });
+  if (!(await verifyHmac(raw, secret, signature))) {
+    return new Response('invalid signature', { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return new Response('bad json', { status: 400 });
+  }
+  const parsed = Payload.safeParse(body);
+  if (!parsed.success) {
+    return new Response(JSON.stringify(parsed.error.issues), { status: 400 });
+  }
+  const p = parsed.data;
+
+  const admin = createClient(Deno.env.get('SUPABASE_URL'), Deno.env.get('SUPABASE_SERVICE_ROLE_KEY'));
+
+  const autoApprove = p.livenessPassed && p.matchScore >= AUTO_APPROVE_THRESHOLD;
+  const newStatus = autoApprove ? 'active' : 'pending_match';
+
+  const { error } = await admin
+    .from('drivers')
+    .update({
+      unico_match_score: p.matchScore,
+      unico_verified_at: p.verifiedAt,
+      status: newStatus,
+    })
+    .eq('id', p.driverId);
+
+  if (error) return new Response(error.message, { status: 500 });
+
+  await admin.from('audit_log').insert({
+    actor: `provider:${p.provider}`,
+    company_id: null,
+    entity_type: 'driver',
+    entity_id: p.driverId,
+    action: 'biometric_verified',
+    payload: { ...p, autoApprove },
+  });
+
+  return new Response(JSON.stringify({ ok: true, autoApprove }), {
+    headers: { 'content-type': 'application/json' },
+  });
+});
+
+async function verifyHmac(body: string, secret: string, hex: string): Promise<boolean> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body));
+  const expected = Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  // timing-safe compare
+  if (expected.length !== hex.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= expected.charCodeAt(i) ^ hex.charCodeAt(i);
+  return diff === 0;
+}

--- a/supabase/migrations/0001_init.sql
+++ b/supabase/migrations/0001_init.sql
@@ -1,0 +1,278 @@
+-- =====================================================================
+-- 0001_init.sql — Schema inicial App Motoristas
+-- =====================================================================
+-- Domínio: prontidão cognitiva pré-jornada B2B.
+-- Multi-tenant por company_id via RLS. Biometria é sensível (LGPD art. 5º II),
+-- por isso nenhuma foto bruta é armazenada aqui — só referências a assets
+-- criptografados em storage e o score retornado pelo provider antifraude.
+-- =====================================================================
+
+create extension if not exists "uuid-ossp";
+create extension if not exists "pgcrypto";
+
+-- ---------------------------------------------------------------------
+-- Tipos
+-- ---------------------------------------------------------------------
+create type traffic_light as enum ('green', 'yellow', 'red');
+create type session_status as enum (
+  'started',       -- iniciou liveness
+  'liveness_ok',   -- liveness aprovado
+  'in_test',       -- bateria cognitiva em andamento
+  'completed',     -- score calculado
+  'aborted',       -- motorista cancelou
+  'fraud_suspect'  -- liveness/reverificação falhou
+);
+create type driver_status as enum ('pending_match', 'active', 'blocked', 'archived');
+create type test_block as enum ('pvt_b', 'divided_attention', 'vigilance');
+
+-- ---------------------------------------------------------------------
+-- Tenants (empresas)
+-- ---------------------------------------------------------------------
+create table companies (
+  id              uuid primary key default uuid_generate_v4(),
+  cnpj            varchar(14) not null unique,
+  legal_name      text not null,
+  trade_name      text,
+  created_at      timestamptz not null default now(),
+  -- Política de bloqueio configurável (JSON) — ex.: {"yellow":"warn","red":"block"}
+  block_policy    jsonb not null default '{"yellow":"warn","red":"block"}'::jsonb,
+  -- Geofencing opcional: { "lat": -23.5, "lng": -46.6, "radius_m": 500 }
+  geofence        jsonb,
+  active          boolean not null default true
+);
+
+-- ---------------------------------------------------------------------
+-- Gestores (usuários do painel) — mapeados para auth.users do Supabase
+-- ---------------------------------------------------------------------
+create table company_members (
+  user_id     uuid primary key references auth.users(id) on delete cascade,
+  company_id  uuid not null references companies(id) on delete cascade,
+  role        text not null check (role in ('owner', 'manager', 'viewer')),
+  created_at  timestamptz not null default now()
+);
+create index on company_members (company_id);
+
+-- ---------------------------------------------------------------------
+-- Motoristas
+-- ---------------------------------------------------------------------
+create table drivers (
+  id                    uuid primary key default uuid_generate_v4(),
+  company_id            uuid not null references companies(id) on delete cascade,
+  full_name             text not null,
+  cpf                   varchar(11) not null,
+  cnh_number            varchar(20) not null,
+  cnh_category          varchar(5),
+  phone                 varchar(20) not null,
+  -- Asset criptografado no Storage (bucket "cnh-photos"); NUNCA a imagem em si.
+  cnh_photo_ref         text,
+  -- Score de similaridade retornado pelo provider antifraude no onboarding.
+  unico_match_score     numeric(5,2),
+  unico_verified_at     timestamptz,
+  -- Device binding: hash do hardware + push token (rotacionado).
+  device_fingerprint    text,
+  device_bound_at       timestamptz,
+  status                driver_status not null default 'pending_match',
+  created_at            timestamptz not null default now(),
+  updated_at            timestamptz not null default now(),
+  unique (company_id, cpf)
+);
+create index on drivers (company_id, status);
+
+-- ---------------------------------------------------------------------
+-- Sessões (uma tentativa de teste pré-jornada)
+-- ---------------------------------------------------------------------
+create table sessions (
+  id                     uuid primary key default uuid_generate_v4(),
+  driver_id              uuid not null references drivers(id) on delete restrict,
+  company_id             uuid not null references companies(id) on delete restrict,
+  started_at             timestamptz not null default now(),
+  completed_at           timestamptz,
+  status                 session_status not null default 'started',
+  -- Geolocalização no momento do teste (PostGIS seria ideal, mas mantendo simples).
+  geo_lat                numeric(9,6),
+  geo_lng                numeric(9,6),
+  inside_geofence        boolean,
+  device_fingerprint     text not null,
+  app_version            text,
+  -- Asset do vídeo de liveness (bucket privado, TTL 90 dias).
+  liveness_video_ref     text,
+  liveness_match_score   numeric(5,2),
+  -- Sessão-pai quando é um reteste (máx 1 retry após amarelo).
+  retry_of_session_id    uuid references sessions(id) on delete set null,
+  -- Hash SHA-256 da sessão fechada — usado para detectar tampering no audit_log.
+  integrity_hash         text
+);
+create index on sessions (driver_id, started_at desc);
+create index on sessions (company_id, started_at desc);
+create index on sessions (company_id, status);
+
+-- ---------------------------------------------------------------------
+-- Resultados dos blocos cognitivos
+-- ---------------------------------------------------------------------
+create table cognitive_results (
+  id           uuid primary key default uuid_generate_v4(),
+  session_id   uuid not null references sessions(id) on delete cascade,
+  block        test_block not null,
+  -- Série temporal crua: [{stimulus_at, response_at, rt_ms, is_lapse, is_false_start}, ...]
+  raw_data     jsonb not null,
+  median_rt_ms numeric(7,2),
+  lapse_rate   numeric(5,4), -- fração de respostas >500 ms
+  cv_rt        numeric(5,4), -- coeficiente de variação (σ/μ)
+  z_score      numeric(6,3),
+  unique (session_id, block)
+);
+create index on cognitive_results (session_id);
+
+-- ---------------------------------------------------------------------
+-- Questionário subjetivo (KSS + Samn-Perelli)
+-- ---------------------------------------------------------------------
+create table subjective_results (
+  session_id      uuid primary key references sessions(id) on delete cascade,
+  -- Karolinska Sleepiness Scale (1-9, onde 9 = extremamente sonolento)
+  kss             smallint not null check (kss between 1 and 9),
+  -- Samn-Perelli Fatigue Scale (1-7, onde 7 = completely exhausted)
+  samn_perelli    smallint not null check (samn_perelli between 1 and 7),
+  -- Horas de sono auto-reportadas na última noite.
+  hours_slept     numeric(3,1),
+  answered_at     timestamptz not null default now()
+);
+
+-- ---------------------------------------------------------------------
+-- Score agregado da sessão
+-- ---------------------------------------------------------------------
+create table session_scores (
+  session_id       uuid primary key references sessions(id) on delete cascade,
+  objective_score  numeric(5,2) not null, -- 0-100 derivado do Z-score PVT
+  subjective_score numeric(5,2) not null, -- 0-100 derivado do KSS/Samn-Perelli
+  final_score      numeric(5,2) not null, -- 60/40 weighted
+  traffic_light    traffic_light not null,
+  blocked          boolean not null,
+  computed_at      timestamptz not null default now(),
+  -- Versão do algoritmo para reprocessamento futuro.
+  algorithm_version text not null default 'v1'
+);
+
+-- ---------------------------------------------------------------------
+-- Audit log append-only (LGPD / SST)
+-- ---------------------------------------------------------------------
+create table audit_log (
+  id           bigserial primary key,
+  occurred_at  timestamptz not null default now(),
+  actor        text not null,   -- 'driver:<uuid>' | 'manager:<uuid>' | 'system'
+  company_id   uuid,
+  entity_type  text not null,   -- 'session' | 'driver' | 'company' | 'score'
+  entity_id    uuid not null,
+  action       text not null,   -- 'created' | 'updated' | 'blocked' | 'exported' | 'deleted'
+  payload      jsonb not null
+);
+create index on audit_log (company_id, occurred_at desc);
+create index on audit_log (entity_type, entity_id);
+
+-- Bloquear updates/deletes no audit_log (apenas INSERTs via trigger ou role service).
+revoke update, delete on audit_log from public;
+
+-- ---------------------------------------------------------------------
+-- Triggers
+-- ---------------------------------------------------------------------
+create or replace function touch_updated_at() returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger drivers_touch before update on drivers
+  for each row execute procedure touch_updated_at();
+
+create or replace function log_session_mutation() returns trigger
+language plpgsql security definer as $$
+begin
+  insert into audit_log (actor, company_id, entity_type, entity_id, action, payload)
+  values (
+    coalesce(current_setting('app.actor', true), 'system'),
+    coalesce(new.company_id, old.company_id),
+    'session',
+    coalesce(new.id, old.id),
+    tg_op,
+    jsonb_build_object('old', to_jsonb(old), 'new', to_jsonb(new))
+  );
+  return coalesce(new, old);
+end;
+$$;
+
+create trigger sessions_audit
+  after insert or update or delete on sessions
+  for each row execute procedure log_session_mutation();
+
+-- ---------------------------------------------------------------------
+-- Row Level Security — isolamento multi-tenant
+-- ---------------------------------------------------------------------
+alter table companies         enable row level security;
+alter table company_members   enable row level security;
+alter table drivers           enable row level security;
+alter table sessions          enable row level security;
+alter table cognitive_results enable row level security;
+alter table subjective_results enable row level security;
+alter table session_scores    enable row level security;
+alter table audit_log         enable row level security;
+
+-- Helper: empresa do usuário autenticado.
+create or replace function current_company_id() returns uuid
+language sql stable as $$
+  select company_id from company_members where user_id = auth.uid() limit 1;
+$$;
+
+-- Gestores só veem a própria empresa.
+create policy company_self_select on companies
+  for select using (id = current_company_id());
+
+create policy members_self_select on company_members
+  for select using (company_id = current_company_id());
+
+create policy drivers_company_rw on drivers
+  for all using (company_id = current_company_id())
+  with check (company_id = current_company_id());
+
+create policy sessions_company_r on sessions
+  for select using (company_id = current_company_id());
+
+create policy cognitive_results_company_r on cognitive_results
+  for select using (
+    session_id in (select id from sessions where company_id = current_company_id())
+  );
+
+create policy subjective_results_company_r on subjective_results
+  for select using (
+    session_id in (select id from sessions where company_id = current_company_id())
+  );
+
+create policy session_scores_company_r on session_scores
+  for select using (
+    session_id in (select id from sessions where company_id = current_company_id())
+  );
+
+create policy audit_company_r on audit_log
+  for select using (company_id = current_company_id());
+
+-- Writes de sessão vêm do app motorista via edge function com service_role,
+-- então não criamos políticas de INSERT/UPDATE para anon/authenticated aqui.
+
+-- ---------------------------------------------------------------------
+-- Views utilitárias para o dashboard
+-- ---------------------------------------------------------------------
+create or replace view v_driver_latest_session as
+select distinct on (d.id)
+  d.id as driver_id,
+  d.company_id,
+  d.full_name,
+  d.status as driver_status,
+  s.id as session_id,
+  s.started_at,
+  s.status as session_status,
+  ss.traffic_light,
+  ss.final_score,
+  ss.blocked
+from drivers d
+left join sessions s on s.driver_id = d.id
+left join session_scores ss on ss.session_id = s.id
+order by d.id, s.started_at desc nulls last;

--- a/supabase/migrations/0002_persist_session_score.sql
+++ b/supabase/migrations/0002_persist_session_score.sql
@@ -1,0 +1,101 @@
+-- RPC used by the compute-session-score edge function.
+-- Wraps all writes (session upsert, block results, subjective, score) into
+-- a single implicit transaction so a partial write never leaves the DB in
+-- an inconsistent state.
+create or replace function persist_session_score(
+  p_session_id uuid,
+  p_driver_id uuid,
+  p_company_id uuid,
+  p_payload jsonb,
+  p_output jsonb
+) returns void
+language plpgsql security definer as $$
+declare
+  v_block jsonb;
+  v_metrics jsonb;
+  v_block_name text;
+begin
+  insert into sessions (
+    id, driver_id, company_id, started_at, completed_at,
+    status, geo_lat, geo_lng, device_fingerprint, app_version,
+    liveness_video_ref, liveness_match_score
+  )
+  values (
+    p_session_id, p_driver_id, p_company_id,
+    (p_payload->>'startedAt')::timestamptz,
+    (p_payload->>'completedAt')::timestamptz,
+    'completed',
+    nullif(p_payload->'geo'->>'lat','')::numeric,
+    nullif(p_payload->'geo'->>'lng','')::numeric,
+    p_payload->>'deviceFingerprint',
+    p_payload->>'appVersion',
+    p_payload->>'livenessVideoRef',
+    nullif(p_payload->>'livenessMatchScore','')::numeric
+  )
+  on conflict (id) do update set
+    completed_at = excluded.completed_at,
+    status = excluded.status,
+    liveness_video_ref = coalesce(excluded.liveness_video_ref, sessions.liveness_video_ref),
+    liveness_match_score = coalesce(excluded.liveness_match_score, sessions.liveness_match_score);
+
+  -- Cognitive block results.
+  for v_block in select * from jsonb_array_elements(p_payload->'blocks')
+  loop
+    v_block_name := v_block->>'block';
+    v_metrics := p_output->'blockMetrics'->v_block_name;
+    insert into cognitive_results (session_id, block, raw_data, median_rt_ms, lapse_rate, cv_rt, z_score)
+    values (
+      p_session_id,
+      v_block_name::test_block,
+      v_block,
+      (v_metrics->>'medianRtMs')::numeric,
+      (v_metrics->>'lapseRate')::numeric,
+      (v_metrics->>'cvRt')::numeric,
+      (v_metrics->>'zScore')::numeric
+    )
+    on conflict (session_id, block) do update set
+      raw_data = excluded.raw_data,
+      median_rt_ms = excluded.median_rt_ms,
+      lapse_rate = excluded.lapse_rate,
+      cv_rt = excluded.cv_rt,
+      z_score = excluded.z_score;
+  end loop;
+
+  -- Subjective.
+  insert into subjective_results (session_id, kss, samn_perelli, hours_slept)
+  values (
+    p_session_id,
+    (p_payload->'subjective'->>'kss')::smallint,
+    (p_payload->'subjective'->>'samnPerelli')::smallint,
+    nullif(p_payload->'subjective'->>'hoursSlept','')::numeric
+  )
+  on conflict (session_id) do update set
+    kss = excluded.kss,
+    samn_perelli = excluded.samn_perelli,
+    hours_slept = excluded.hours_slept;
+
+  -- Final score.
+  insert into session_scores (
+    session_id, objective_score, subjective_score, final_score,
+    traffic_light, blocked, algorithm_version
+  )
+  values (
+    p_session_id,
+    (p_output->>'objectiveScore')::numeric,
+    (p_output->>'subjectiveScore')::numeric,
+    (p_output->>'finalScore')::numeric,
+    (p_output->>'trafficLight')::traffic_light,
+    (p_output->>'blocked')::boolean,
+    coalesce(p_output->>'algorithmVersion','v1')
+  )
+  on conflict (session_id) do update set
+    objective_score = excluded.objective_score,
+    subjective_score = excluded.subjective_score,
+    final_score = excluded.final_score,
+    traffic_light = excluded.traffic_light,
+    blocked = excluded.blocked,
+    algorithm_version = excluded.algorithm_version;
+end;
+$$;
+
+revoke all on function persist_session_score(uuid, uuid, uuid, jsonb, jsonb) from public;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,11 @@
+-- Seed de desenvolvimento — NÃO usar em produção.
+insert into companies (id, cnpj, legal_name, trade_name)
+values
+  ('00000000-0000-0000-0000-000000000001', '12345678000100', 'Transportadora Demo LTDA', 'Demo Transp');
+
+insert into drivers (id, company_id, full_name, cpf, cnh_number, phone, status, unico_match_score, unico_verified_at)
+values
+  ('10000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001',
+   'João da Silva', '11122233344', 'CNH-123456', '+5511999990001', 'active', 96.4, now()),
+  ('10000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001',
+   'Maria Oliveira', '55566677788', 'CNH-654321', '+5511999990002', 'active', 93.2, now());

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
## Contexto

Bootstrap completo do app de **teste de prontidão cognitiva pré-jornada** para motoristas de frota. Diferencia-se das ferramentas atuais (CogniFit, PREDICT, exames psicotécnicos genéricos) por ser:

- **Rápido** (~75 s) e pensado para rodar **antes** da jornada.
- **B2B para transportadoras** com painel de gestão, política de bloqueio, auditoria.
- **Antifraude por design**, inspirado no método do Detran para cursos EAD de reciclagem: match facial contra a base CNH via SaaS BR (Unico/Idwall/Serpro), liveness ativo, reverificação silenciosa durante o teste, device binding e geofence.

## Stack (decisões do PM)

| Camada | Escolha |
|---|---|
| App motorista | React Native + Expo (Android-first) |
| Painel gestor | Next.js 15 |
| Backend | Supabase (Postgres + Auth + Storage + Edge Functions) |
| Biometria | SaaS BR (Unico/Idwall/Serpro) com match CNH |

## Resumo dos módulos

| Caminho | O que faz |
|---|---|
| `packages/shared-types` | Contratos Zod (SessionSubmission, Trial, SessionScore…) |
| `packages/scoring` | Motor puro: Z-score PVT + KSS + Samn-Perelli + cutoffs + hard-red rules. **18/18 testes Vitest.** |
| `packages/cognitive-tests` | PVT-B controller framework-agnóstico (event-driven, determinístico com seed). **6/6 testes.** |
| `apps/mobile` | Expo Router: onboarding (SMS OTP) + fluxo pré-jornada (liveness → PVT → subjetivo → score) |
| `apps/dashboard` | Lista de motoristas, drill-down por sessão, login |
| `supabase/migrations/0001_init.sql` | Schema multi-tenant + RLS por `company_id` + `audit_log` append-only via trigger |
| `supabase/migrations/0002_persist_session_score.sql` | RPC transacional chamado pela edge function |
| `supabase/functions/compute-session-score` | Valida JWT, chama scorer, persiste via RPC |
| `supabase/functions/unico-webhook` | Callback do provider biométrico com verificação HMAC |
| `docs/lgpd-dpia.md` | DPIA LGPD (biometria = dado sensível) |
| `docs/antifraud-controls.md` | Matriz de controles antifraude |
| `docs/scoring-methodology.md` | Detalhes científicos do scoring |

## Bateria cognitiva

| Bloco | Duração | Métrica |
|---|---|---|
| PVT-B (reação) | 30 s | Mediana RT, lapse rate, CV RT |
| Atenção dividida | 20 s | Acertos/omissões (placeholder, Fase 1 completa PVT-B) |
| Vigilância | 25 s | Consistência do RT |

Scoring: `0.6 * objetivo + 0.4 * subjetivo` → semáforo, com regras hard-red (lapse rate > 20 %, KSS ≥ 8, Samn-Perelli ≥ 6) que forçam vermelho.

## Test plan

- [x] `pnpm -r --filter=./packages/* test` — 24/24 verde
- [x] `pnpm -r --filter=./packages/* typecheck` — limpo
- [ ] `supabase start && supabase db reset` — aplicar schema localmente
- [ ] `pnpm dashboard:dev` — login + lista de motoristas com seed
- [ ] `pnpm mobile:start` — fluxo completo em device Android real
- [ ] Benchmark de latência de toque em Android gama baixa (desvio <15 % vs laptop)
- [ ] Validar RLS tentando query cross-tenant (deve retornar vazio)
- [ ] E2E com Maestro (Fase 2)

## Próximos passos (fora deste PR)

- Configurar projeto Supabase (URLs + keys nos `.env.example`)
- Contratar provider biométrico e expor SDK no mobile (o `liveness.tsx` é placeholder)
- Implementar blocos de atenção dividida e vigilância
- Fase de coleta-sombra (30 dias com `policy.red = warn`) antes de ligar bloqueio

https://claude.ai/code/session_01TSuXQbBq2zRFv1BpXRun8o