### PR TITLE
feat: tooling + templates de deploy

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,0 +1,35 @@
+name: Deploy dashboard (Vercel)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/dashboard/**'
+      - 'packages/shared-types/**'
+      - '.github/workflows/deploy-dashboard.yml'
+  workflow_dispatch:
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_DASHBOARD }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile=false
+      - name: Pull Vercel environment
+        run: pnpm dlx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: apps/dashboard
+      - name: Build with Vercel
+        run: pnpm dlx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: apps/dashboard
+      - name: Deploy to Vercel
+        run: pnpm dlx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: apps/dashboard

--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -1,0 +1,31 @@
+name: Deploy Supabase (DB + functions)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+      - 'supabase/functions/**'
+      - '.github/workflows/deploy-supabase.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+      - name: Push DB migrations
+        run: supabase db push --password "$SUPABASE_DB_PASSWORD"
+      - name: Deploy edge functions
+        run: |
+          supabase functions deploy compute-session-score --no-verify-jwt=false
+          supabase functions deploy unico-webhook --no-verify-jwt

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=wekycrnahqcpnmlmfdvv"
+    }
+  }
+}

--- a/apps/mobile/src/lib/biometric-provider.ts
+++ b/apps/mobile/src/lib/biometric-provider.ts
@@ -1,0 +1,94 @@
+// Thin abstraction over whichever biometric SaaS we integrate.
+// Implementing a single interface lets us swap Unico / Idwall / Serpro without
+// touching the session flow. Each `verify` call must POST to a **backend**
+// endpoint that holds the provider secret — the SDK is the UI only, never
+// credentials. See docs/antifraud-controls.md for the full threat model.
+
+export interface OnboardingVerification {
+  matchScore: number; // 0-100 similarity vs CNH photo
+  livenessPassed: boolean;
+  providerTxId: string; // provider's transaction id for auditing
+}
+
+export interface LivenessChallenge {
+  videoRef: string; // bucket object key (uploaded by the provider SDK)
+  matchScore: number; // 0-100 similarity vs enrollment photo
+  livenessPassed: boolean;
+  providerTxId: string;
+}
+
+export interface BiometricProvider {
+  /**
+   * Onboarding: match the driver's live selfie against the CNH photo in the
+   * provider's reference database. Returns a similarity score; caller decides
+   * what to do with the value (>=90 auto-approve, 80-89 manual review).
+   */
+  runOnboardingMatch(input: {
+    driverId: string;
+    cnhNumber: string;
+    cpf: string;
+  }): Promise<OnboardingVerification>;
+
+  /**
+   * Pre-journey liveness: random prompt sequence (blink / turn head) to prove
+   * the person is physically present and alive. Typically ~6-8s.
+   */
+  runLivenessChallenge(input: { driverId: string; sessionId: string }): Promise<LivenessChallenge>;
+
+  /**
+   * Silent re-verification during the cognitive test — captures a single frame
+   * and compares against enrollment. Fire-and-forget from the UI perspective.
+   */
+  runSilentReverify(input: { driverId: string; sessionId: string }): Promise<{
+    matchScore: number;
+    providerTxId: string;
+  }>;
+}
+
+// Picks the concrete implementation based on EXPO_PUBLIC_BIOMETRIC_PROVIDER.
+// Individual implementations live in `providers/` — today only the stub is
+// wired so the mobile app builds end-to-end before vendor lock-in decisions.
+export async function getBiometricProvider(): Promise<BiometricProvider> {
+  const name = process.env.EXPO_PUBLIC_BIOMETRIC_PROVIDER ?? 'stub';
+  switch (name) {
+    case 'unico':
+      // TODO(#4): replace once @unico-check/react-native is contracted.
+      //   return (await import('./providers/unico')).UnicoProvider;
+      return stubProvider;
+    case 'idwall':
+      // TODO(#4): idwall implementation.
+      return stubProvider;
+    case 'serpro':
+      // TODO(#4): serpro implementation (may need Idwall as integrator).
+      return stubProvider;
+    default:
+      return stubProvider;
+  }
+}
+
+const stubProvider: BiometricProvider = {
+  async runOnboardingMatch() {
+    warnStub('runOnboardingMatch');
+    return { matchScore: 99, livenessPassed: true, providerTxId: `stub-${Date.now()}` };
+  },
+  async runLivenessChallenge({ sessionId }) {
+    warnStub('runLivenessChallenge');
+    return {
+      videoRef: `liveness-videos/${sessionId}.mp4`,
+      matchScore: 99,
+      livenessPassed: true,
+      providerTxId: `stub-${sessionId}`,
+    };
+  },
+  async runSilentReverify() {
+    return { matchScore: 99, providerTxId: `stub-${Date.now()}` };
+  },
+};
+
+let warned = new Set<string>();
+function warnStub(method: string) {
+  if (warned.has(method)) return;
+  warned.add(method);
+  // eslint-disable-next-line no-console
+  console.warn(`[biometric] using STUB provider for ${method} — see issue #4`);
+}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,54 @@
+# Guia de Deploy
+
+## 1. Local (desenvolvimento)
+
+### Pré-requisitos
+- Node 20+, `pnpm`, Docker, `supabase` CLI (`npm i -g supabase`).
+
+### Passos
+```bash
+pnpm install
+./scripts/supabase-setup.sh           # sobe Supabase local + gera .env.local nos apps
+pnpm dashboard:dev                     # http://localhost:3000
+pnpm mobile:start                      # abre Expo DevTools
+```
+
+## 2. Produção
+
+Temos dois workflows de deploy automáticos disparados por push em `main`:
+
+### Supabase (schema + edge functions) — `.github/workflows/deploy-supabase.yml`
+Secrets necessários no GitHub Actions:
+- `SUPABASE_ACCESS_TOKEN` — personal token do dono da org (**Settings → Access Tokens**)
+- `SUPABASE_PROJECT_REF` — ex.: `abcdxyz`
+- `SUPABASE_DB_PASSWORD`
+- `BIOMETRIC_WEBHOOK_SECRET` — setado via `supabase secrets set` (CLI), não via GH
+
+### Dashboard (Vercel) — `.github/workflows/deploy-dashboard.yml`
+Secrets necessários:
+- `VERCEL_TOKEN` (**Vercel → Account → Tokens**)
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID_DASHBOARD`
+
+Variáveis de ambiente do projeto Vercel (preencher no painel):
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+### Mobile (EAS Build — não automatizado no CI ainda)
+```bash
+cd apps/mobile
+eas login
+eas build --platform android --profile preview     # APK para piloto
+eas submit --platform android                      # Play Store
+```
+
+## 3. Ordem de operação no go-live
+
+1. Destravar billing do GitHub Actions (issue #2).
+2. Criar projeto Supabase e rodar `deploy-supabase.yml` (issue #3).
+3. Configurar provider biométrico e setar `BIOMETRIC_WEBHOOK_SECRET` via `supabase secrets set` (issue #4).
+4. Subir dashboard na Vercel (`deploy-dashboard.yml`).
+5. Gerar APK de piloto via EAS e distribuir para a transportadora-parceira.
+6. Rodar 30 dias de coleta-sombra com `block_policy = warn/warn` (issue #5).
+7. Recalibrar cutoffs e só então ligar bloqueio.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lint": "pnpm -r lint",
     "dashboard:dev": "pnpm --filter @app-motoristas/dashboard dev",
     "mobile:start": "pnpm --filter @app-motoristas/mobile start",
-    "supabase:reset": "supabase db reset"
+    "supabase:reset": "supabase db reset",
+    "supabase:setup": "./scripts/supabase-setup.sh",
+    "supabase:deploy": "./scripts/supabase-setup.sh --remote"
   },
   "devDependencies": {
     "typescript": "5.6.3",

--- a/scripts/supabase-setup.sh
+++ b/scripts/supabase-setup.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Bootstrap local Supabase + generate .env files for both apps.
+#
+# Usage:
+#   ./scripts/supabase-setup.sh            # local stack (Docker) + reset DB
+#   ./scripts/supabase-setup.sh --remote   # assume you already ran `supabase link`
+#
+# Requires: supabase CLI (`brew install supabase/tap/supabase` or `npm i -g supabase`).
+
+set -euo pipefail
+
+MODE="${1:-local}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "❌ supabase CLI not found. Install it: npm i -g supabase" >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "--remote" ]]; then
+  echo "📡 Remote mode — assuming 'supabase link' already ran."
+  supabase db push
+  echo "✅ Migrations pushed to remote."
+  exit 0
+fi
+
+echo "🐳 Starting local Supabase stack (Postgres + Auth + Storage + Edge Functions)…"
+supabase start
+
+echo "🗄  Applying migrations + seed…"
+supabase db reset
+
+# Parse CLI output into .env for each app.
+STATUS=$(supabase status --output json)
+API_URL=$(echo "$STATUS" | grep -o '"API URL":"[^"]*' | cut -d'"' -f4 | head -n1)
+ANON_KEY=$(echo "$STATUS" | grep -o '"anon key":"[^"]*' | cut -d'"' -f4 | head -n1)
+SERVICE_ROLE=$(echo "$STATUS" | grep -o '"service_role key":"[^"]*' | cut -d'"' -f4 | head -n1)
+
+write_env() {
+  local path="$1"
+  shift
+  echo "$@" > "$path"
+  echo "📝 wrote $path"
+}
+
+write_env apps/mobile/.env.local \
+"EXPO_PUBLIC_SUPABASE_URL=$API_URL
+EXPO_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY
+EXPO_PUBLIC_BIOMETRIC_PROVIDER=unico"
+
+write_env apps/dashboard/.env.local \
+"NEXT_PUBLIC_SUPABASE_URL=$API_URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY
+SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE"
+
+echo ""
+echo "✅ Ready:"
+echo "   Studio: $(echo "$STATUS" | grep -o '"Studio URL":"[^"]*' | cut -d'"' -f4 | head -n1)"
+echo "   API:    $API_URL"
+echo ""
+echo "Next: pnpm dashboard:dev  (or pnpm mobile:start)"


### PR DESCRIPTION
## Contexto

Segundo PR, empilhado em cima de #1. Reduz a fricção dos próximos 4 passos sem código novo:

- #2 billing (não dá fazer via MCP — apenas tracking)
- #3 Supabase → `scripts/supabase-setup.sh` + workflow `deploy-supabase.yml`
- #4 Biometria → `apps/mobile/src/lib/biometric-provider.ts` (interface + stub) preparado para Unico/Idwall/Serpro
- #5 Piloto → runbook em `docs/deploy.md`

## Arquivos

| Arquivo | O que faz |
|---|---|
| `scripts/supabase-setup.sh` | Sobe Supabase local (Docker) + gera `.env.local` dos 2 apps a partir do `supabase status`. Suporta `--remote` após `supabase link`. |
| `apps/mobile/src/lib/biometric-provider.ts` | Interface `BiometricProvider` (onboarding, liveness, silent reverify) + stub default + switch por env `EXPO_PUBLIC_BIOMETRIC_PROVIDER`. TODOs apontam para #4. |
| `.github/workflows/deploy-dashboard.yml` | Deploy Vercel disparado por push em `main` (paths-filtered). |
| `.github/workflows/deploy-supabase.yml` | `supabase db push` + `functions deploy` em push em `main`. |
| `docs/deploy.md` | Runbook end-to-end: local → produção + ordem de go-live referenciando #2–#5. |
| `package.json` | Novos scripts `supabase:setup` e `supabase:deploy`. |

## Test plan

- [ ] `./scripts/supabase-setup.sh` em máquina com Docker → confere que `.env.local` nasce preenchido em ambos os apps
- [ ] Após billing (#2) destravar, os workflows aparecem mas só rodam em `main` — verificar que não quebram o PR
- [ ] Substituir o stub em `biometric-provider.ts` quando o SDK Unico chegar (#4)

## Stack do PR

`main` ← #1 ← **#this** (empilhado). Mergear #1 primeiro; aí o base deste PR migra para `main` automaticamente.

https://claude.ai/code/session_01TSuXQbBq2zRFv1BpXRun8o