### PR TITLE
fix(ci): harden supabase deploy workflow

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -21,11 +21,31 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: latest
-      - name: Link project
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
-      - name: Push DB migrations
-        run: supabase db push --password "$SUPABASE_DB_PASSWORD"
-      - name: Deploy edge functions
+
+      - name: Diagnose secrets
         run: |
-          supabase functions deploy compute-session-score --no-verify-jwt=false
-          supabase functions deploy unico-webhook --no-verify-jwt
+          fail=0
+          for name in SUPABASE_ACCESS_TOKEN SUPABASE_PROJECT_REF SUPABASE_DB_PASSWORD; do
+            val="${!name}"
+            if [ -z "$val" ]; then
+              echo "::error::$name is MISSING — add it at Settings → Secrets → Actions"
+              fail=1
+            else
+              len=${#val}
+              echo "$name: set (length=$len)"
+            fi
+          done
+          if [ "$fail" -eq 1 ]; then exit 1; fi
+
+      - name: Apply DB migrations
+        env:
+          PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          DB_URL="postgresql://postgres:${PGPASSWORD}@db.${SUPABASE_PROJECT_REF}.supabase.co:5432/postgres"
+          supabase db push --db-url "$DB_URL"
+
+      - name: Deploy edge function (compute-session-score)
+        run: supabase functions deploy compute-session-score --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Deploy edge function (unico-webhook)
+        run: supabase functions deploy unico-webhook --project-ref "$SUPABASE_PROJECT_REF" --no-verify-jwt


### PR DESCRIPTION
## Contexto

Workflow `Deploy Supabase` falhou no primeiro run ([24642210984](https://github.com/KallebyX/App-motoristas/actions/runs/24642210984)) em 8s no step `Link project` (exit code 1). Causa provável: secret faltando ou `supabase link` exigindo input interativo.

## Mudanças

1. **Diagnostic step** antes de tudo: imprime `set (length=N)` ou `::error:: MISSING` para cada um dos 3 secrets (sem revelar valores).
2. **`supabase link` removido.** Substituído por `supabase db push --db-url postgresql://postgres:$PW@db.$REF.supabase.co:5432/postgres` — conexão direta, sem prompt.
3. **Functions deploy** com 1 step por function e `--project-ref` explícito.
4. Fix do flag `--no-verify-jwt=false` que era inválido.

https://claude.ai/code/session_01TSuXQbBq2zRFv1BpXRun8o