### PR TITLE
fix(security): address 7 critical review findings (RLS, storage, scoring penalty, Next CVE)

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -13,7 +13,7 @@
     "@app-motoristas/shared-types": "workspace:*",
     "@supabase/ssr": "0.5.2",
     "@supabase/supabase-js": "2.46.1",
-    "next": "15.0.3",
+    "next": "15.2.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "zod": "3.23.8"
@@ -23,7 +23,7 @@
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "eslint": "8.57.1",
-    "eslint-config-next": "15.0.3",
+    "eslint-config-next": "15.2.3",
     "typescript": "5.6.3"
   }
 }

--- a/apps/dashboard/src/app/analytics/page.tsx
+++ b/apps/dashboard/src/app/analytics/page.tsx
@@ -2,12 +2,6 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getSupabaseServerClient } from '@/lib/supabase-server';
 
-interface SessionRow {
-  started_at: string;
-  traffic_light: 'green' | 'yellow' | 'red' | null;
-  final_score: number | null;
-}
-
 interface CognitiveRow {
   median_rt_ms: number | null;
   lapse_rate: number | null;
@@ -22,11 +16,7 @@ export default async function AnalyticsPage() {
   const since = new Date();
   since.setDate(since.getDate() - 14);
 
-  const [{ data: sessions }, { data: cognitive }, { data: scores }] = await Promise.all([
-    supabase
-      .from('sessions')
-      .select('started_at, session_scores(traffic_light, final_score)')
-      .gte('started_at', since.toISOString()) as unknown as Promise<{ data: SessionRow[] | null }>,
+  const [{ data: cognitive }, { data: scores }] = await Promise.all([
     supabase
       .from('cognitive_results')
       .select('median_rt_ms, lapse_rate, cv_rt, sessions!inner(started_at)')
@@ -34,9 +24,9 @@ export default async function AnalyticsPage() {
       .eq('block', 'pvt_b') as unknown as Promise<{ data: CognitiveRow[] | null }>,
     supabase
       .from('session_scores')
-      .select('final_score, traffic_light, sessions!inner(started_at)')
+      .select('final_score, traffic_light, sessions!inner(started_at, driver_id)')
       .gte('sessions.started_at', since.toISOString()) as unknown as Promise<{
-      data: { final_score: number; traffic_light: string }[] | null;
+      data: { final_score: number | null; traffic_light: string | null; sessions: { driver_id: string } }[] | null;
     }>,
   ]);
 
@@ -50,16 +40,28 @@ export default async function AnalyticsPage() {
   const redRate = total === 0 ? 0 : trafficLightCounts.red / total;
 
   const rtBuckets = histogram(
-    (cognitive ?? []).map((r) => Number(r.median_rt_ms)).filter((v) => !isNaN(v)),
+    (cognitive ?? [])
+      .filter((r) => r.median_rt_ms != null)
+      .map((r) => Number(r.median_rt_ms))
+      .filter((v) => !isNaN(v)),
     [200, 250, 300, 350, 400, 450, 500, 600],
   );
   const lapseBuckets = histogram(
-    (cognitive ?? []).map((r) => Number(r.lapse_rate) * 100).filter((v) => !isNaN(v)),
+    (cognitive ?? [])
+      .filter((r) => r.lapse_rate != null)
+      .map((r) => Number(r.lapse_rate) * 100)
+      .filter((v) => !isNaN(v)),
     [0, 2, 5, 10, 15, 20, 30, 50],
   );
 
-  const finalScores = scoreRows.map((r) => Number(r.final_score)).filter((v) => !isNaN(v));
+  const finalScores = scoreRows
+    .filter((r) => r.final_score != null)
+    .map((r) => Number(r.final_score))
+    .filter((v) => !isNaN(v));
   const avgScore = finalScores.length === 0 ? 0 : finalScores.reduce((a, b) => a + b, 0) / finalScores.length;
+
+  // Distinct driver_ids, not rows.
+  const activeDrivers = new Set(scoreRows.map((r) => r.sessions?.driver_id).filter(Boolean)).size;
 
   const goNoGo = {
     sampleSize: { value: total, target: 500, ok: total >= 500 },
@@ -82,7 +84,7 @@ export default async function AnalyticsPage() {
         <Stat label="Sessões" value={total.toString()} />
         <Stat label="Score médio" value={avgScore.toFixed(1)} />
         <Stat label="Taxa de vermelho" value={`${(redRate * 100).toFixed(1)}%`} />
-        <Stat label="Motoristas ativos" value={Array.from(new Set(scoreRows)).length.toString()} />
+        <Stat label="Motoristas ativos" value={activeDrivers.toString()} />
       </section>
 
       <section style={{ marginBottom: 24 }}>

--- a/apps/dashboard/src/app/sessions/[id]/page.tsx
+++ b/apps/dashboard/src/app/sessions/[id]/page.tsx
@@ -103,7 +103,9 @@ export default async function SessionDetailPage({ params }: { params: Promise<{ 
           <p style={{ margin: 0 }}>
             Liveness: <strong>{session.liveness_match_score ?? '—'}%</strong>
           </p>
-          <p style={{ margin: '8px 0 0' }}>Device: {session.device_fingerprint.slice(0, 16)}…</p>
+          <p style={{ margin: '8px 0 0' }}>
+            Device: {session.device_fingerprint ? `${session.device_fingerprint.slice(0, 16)}…` : '—'}
+          </p>
           <p style={{ margin: '8px 0 0' }}>
             Geofence: <strong>{session.inside_geofence == null ? '—' : session.inside_geofence ? 'OK' : 'FORA'}</strong>
           </p>

--- a/packages/scoring/src/scorer.test.ts
+++ b/packages/scoring/src/scorer.test.ts
@@ -183,6 +183,29 @@ describe('scoreSession — metrics sanity', () => {
   });
 });
 
+describe('scoreSession — block with zero valid trials', () => {
+  it('penalizes (not rewards) a block where every trial is a false start', () => {
+    const block: BlockResult = {
+      block: 'pvt_b',
+      startedAt: '2026-04-19T12:00:00.000Z',
+      endedAt: '2026-04-19T12:00:30.000Z',
+      trials: Array.from({ length: 5 }, () => ({
+        stimulusAtMs: 0,
+        responseAtMs: 50,
+        rtMs: null,
+        isLapse: false,
+        isFalseStart: true,
+      })),
+    };
+    const out = scoreSession({
+      submission: makeSubmission({ blocks: [block] }),
+      policy: strictPolicy,
+    });
+    expect(out.trafficLight).toBe('red');
+    expect(out.blockMetrics['pvt_b']!.zScore).toBe(-4);
+  });
+});
+
 describe('scoreSession — output contract', () => {
   it('always includes algorithm version and numeric scores', () => {
     const out = scoreSession({ submission: makeSubmission(), policy: strictPolicy });

--- a/packages/scoring/src/scorer.ts
+++ b/packages/scoring/src/scorer.ts
@@ -37,12 +37,24 @@ export function computeBlockMetrics(block: BlockResult): BlockMetrics {
   const validTrials: Trial[] = block.trials.filter((t) => !t.isFalseStart && t.rtMs != null);
   const rts = validTrials.map((t) => t.rtMs as number);
   const falseStarts = block.trials.filter((t) => t.isFalseStart).length;
-
-  const med = rts.length > 0 ? median(rts) : 0;
-  const lapses = validTrials.filter((t) => t.isLapse).length;
-  const lapseRate = validTrials.length > 0 ? lapses / validTrials.length : 0;
-  const cv = rts.length > 1 ? coefficientOfVariation(rts) : 0;
   const falseStartRate = block.trials.length > 0 ? falseStarts / block.trials.length : 0;
+
+  // Block with zero valid responses is a hard penalty. Returning zeros would
+  // produce an artificially high z-score, turning an invalid session green.
+  if (validTrials.length === 0) {
+    return {
+      medianRtMs: PVT_B_NORMS.medianRtMs.mean + 4 * PVT_B_NORMS.medianRtMs.sd,
+      lapseRate: 1,
+      cvRt: PVT_B_NORMS.cvRt.mean + 4 * PVT_B_NORMS.cvRt.sd,
+      falseStartRate,
+      zScore: -4,
+    };
+  }
+
+  const med = median(rts);
+  const lapses = validTrials.filter((t) => t.isLapse).length;
+  const lapseRate = lapses / validTrials.length;
+  const cv = rts.length > 1 ? coefficientOfVariation(rts) : 0;
 
   // Compose a single Z for the block: average across RT, lapses and CV (higher = worse).
   // Negate so that LOWER RT/lapse → positive Z (better performance).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 2.46.1
         version: 2.46.1
       next:
-        specifier: 15.0.3
-        version: 15.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 15.2.3
+        version: 15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -55,8 +55,8 @@ importers:
         specifier: 8.57.1
         version: 8.57.1
       eslint-config-next:
-        specifier: 15.0.3
-        version: 15.0.3(eslint@8.57.1)(typescript@5.6.3)
+        specifier: 15.2.3
+        version: 15.2.3(eslint@8.57.1)(typescript@5.6.3)
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -1360,56 +1360,56 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@15.0.3':
-    resolution: {integrity: sha512-t9Xy32pjNOvVn2AS+Utt6VmyrshbpfUMhIjFO60gI58deSo/KgLOp31XZ4O+kY/Is8WAGYwA5gR7kOb1eORDBA==}
+  '@next/env@15.2.3':
+    resolution: {integrity: sha512-a26KnbW9DFEUsSxAxKBORR/uD9THoYoKbkpFywMN/AFvboTt94b8+g/07T8J6ACsdLag8/PDU60ov4rPxRAixw==}
 
-  '@next/eslint-plugin-next@15.0.3':
-    resolution: {integrity: sha512-3Ln/nHq2V+v8uIaxCR6YfYo7ceRgZNXfTd3yW1ukTaFbO+/I8jNakrjYWODvG9BuR2v5kgVtH/C8r0i11quOgw==}
+  '@next/eslint-plugin-next@15.2.3':
+    resolution: {integrity: sha512-eNSOIMJtjs+dp4Ms1tB1PPPJUQHP3uZK+OQ7iFY9qXpGO6ojT6imCL+KcUOqE/GXGidWbBZJzYdgAdPHqeCEPA==}
 
-  '@next/swc-darwin-arm64@15.0.3':
-    resolution: {integrity: sha512-s3Q/NOorCsLYdCKvQlWU+a+GeAd3C8Rb3L1YnetsgwXzhc3UTWrtQpB/3eCjFOdGUj5QmXfRak12uocd1ZiiQw==}
+  '@next/swc-darwin-arm64@15.2.3':
+    resolution: {integrity: sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.0.3':
-    resolution: {integrity: sha512-Zxl/TwyXVZPCFSf0u2BNj5sE0F2uR6iSKxWpq4Wlk/Sv9Ob6YCKByQTkV2y6BCic+fkabp9190hyrDdPA/dNrw==}
+  '@next/swc-darwin-x64@15.2.3':
+    resolution: {integrity: sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.0.3':
-    resolution: {integrity: sha512-T5+gg2EwpsY3OoaLxUIofmMb7ohAUlcNZW0fPQ6YAutaWJaxt1Z1h+8zdl4FRIOr5ABAAhXtBcpkZNwUcKI2fw==}
+  '@next/swc-linux-arm64-gnu@15.2.3':
+    resolution: {integrity: sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.0.3':
-    resolution: {integrity: sha512-WkAk6R60mwDjH4lG/JBpb2xHl2/0Vj0ZRu1TIzWuOYfQ9tt9NFsIinI1Epma77JVgy81F32X/AeD+B2cBu/YQA==}
+  '@next/swc-linux-arm64-musl@15.2.3':
+    resolution: {integrity: sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.0.3':
-    resolution: {integrity: sha512-gWL/Cta1aPVqIGgDb6nxkqy06DkwJ9gAnKORdHWX1QBbSZZB+biFYPFti8aKIQL7otCE1pjyPaXpFzGeG2OS2w==}
+  '@next/swc-linux-x64-gnu@15.2.3':
+    resolution: {integrity: sha512-ODSKvrdMgAJOVU4qElflYy1KSZRM3M45JVbeZu42TINCMG3anp7YCBn80RkISV6bhzKwcUqLBAmOiWkaGtBA9w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.0.3':
-    resolution: {integrity: sha512-QQEMwFd8r7C0GxQS62Zcdy6GKx999I/rTO2ubdXEe+MlZk9ZiinsrjwoiBL5/57tfyjikgh6GOU2WRQVUej3UA==}
+  '@next/swc-linux-x64-musl@15.2.3':
+    resolution: {integrity: sha512-ZR9kLwCWrlYxwEoytqPi1jhPd1TlsSJWAc+H/CJHmHkf2nD92MQpSRIURR1iNgA/kuFSdxB8xIPt4p/T78kwsg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.0.3':
-    resolution: {integrity: sha512-9TEp47AAd/ms9fPNgtgnT7F3M1Hf7koIYYWCMQ9neOwjbVWJsHZxrFbI3iEDJ8rf1TDGpmHbKxXf2IFpAvheIQ==}
+  '@next/swc-win32-arm64-msvc@15.2.3':
+    resolution: {integrity: sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.0.3':
-    resolution: {integrity: sha512-VNAz+HN4OGgvZs6MOoVfnn41kBzT+M+tB+OK4cww6DNyWS6wKaDpaAm/qLeOUbnMh0oVx1+mg0uoYARF69dJyA==}
+  '@next/swc-win32-x64-msvc@15.2.3':
+    resolution: {integrity: sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1821,8 +1821,8 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/helpers@0.5.13':
-    resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -2895,8 +2895,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@15.0.3:
-    resolution: {integrity: sha512-IGP2DdQQrgjcr4mwFPve4DrCqo7CVVez1WoYY47XwKSrYO4hC0Dlb+iJA60i0YfICOzgNADIb8r28BpQ5Zs0wg==}
+  eslint-config-next@15.2.3:
+    resolution: {integrity: sha512-VDQwbajhNMFmrhLWVyUXCqsGPN+zz5G8Ys/QwFubfsxTIrkqdx3N3x3QPW+pERz8bzGPP0IgEm8cNbZcd8PFRQ==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
       typescript: '>=3.3.1'
@@ -4215,8 +4215,8 @@ packages:
   nested-error-stacks@2.0.1:
     resolution: {integrity: sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==}
 
-  next@15.0.3:
-    resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
+  next@15.2.3:
+    resolution: {integrity: sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
@@ -4224,8 +4224,8 @@ packages:
       '@opentelemetry/api': ^1.1.0
       '@playwright/test': ^1.41.2
       babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-66855b96-20241106
-      react-dom: ^18.2.0 || 19.0.0-rc-66855b96-20241106
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -7241,34 +7241,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.0.3': {}
+  '@next/env@15.2.3': {}
 
-  '@next/eslint-plugin-next@15.0.3':
+  '@next/eslint-plugin-next@15.2.3':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.0.3':
+  '@next/swc-darwin-arm64@15.2.3':
     optional: true
 
-  '@next/swc-darwin-x64@15.0.3':
+  '@next/swc-darwin-x64@15.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.0.3':
+  '@next/swc-linux-arm64-gnu@15.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.0.3':
+  '@next/swc-linux-arm64-musl@15.2.3':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.0.3':
+  '@next/swc-linux-x64-gnu@15.2.3':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.0.3':
+  '@next/swc-linux-x64-musl@15.2.3':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.0.3':
+  '@next/swc-win32-arm64-msvc@15.2.3':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.0.3':
+  '@next/swc-win32-x64-msvc@15.2.3':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -7884,7 +7884,7 @@ snapshots:
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/helpers@0.5.13':
+  '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
 
@@ -9070,9 +9070,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@15.0.3(eslint@8.57.1)(typescript@5.6.3):
+  eslint-config-next@15.2.3(eslint@8.57.1)(typescript@5.6.3):
     dependencies:
-      '@next/eslint-plugin-next': 15.0.3
+      '@next/eslint-plugin-next': 15.2.3
       '@rushstack/eslint-patch': 1.16.1
       '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/parser': 8.59.0(eslint@8.57.1)(typescript@5.6.3)
@@ -10663,11 +10663,11 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@15.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 15.0.3
+      '@next/env': 15.2.3
       '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.13
+      '@swc/helpers': 0.5.15
       busboy: 1.6.0
       caniuse-lite: 1.0.30001788
       postcss: 8.4.31
@@ -10675,14 +10675,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.0.3
-      '@next/swc-darwin-x64': 15.0.3
-      '@next/swc-linux-arm64-gnu': 15.0.3
-      '@next/swc-linux-arm64-musl': 15.0.3
-      '@next/swc-linux-x64-gnu': 15.0.3
-      '@next/swc-linux-x64-musl': 15.0.3
-      '@next/swc-win32-arm64-msvc': 15.0.3
-      '@next/swc-win32-x64-msvc': 15.0.3
+      '@next/swc-darwin-arm64': 15.2.3
+      '@next/swc-darwin-x64': 15.2.3
+      '@next/swc-linux-arm64-gnu': 15.2.3
+      '@next/swc-linux-arm64-musl': 15.2.3
+      '@next/swc-linux-x64-gnu': 15.2.3
+      '@next/swc-linux-x64-musl': 15.2.3
+      '@next/swc-win32-arm64-msvc': 15.2.3
+      '@next/swc-win32-x64-msvc': 15.2.3
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'

--- a/supabase/functions/_shared/scoring.ts
+++ b/supabase/functions/_shared/scoring.ts
@@ -138,11 +138,21 @@ export function computeBlockMetrics(block: BlockResult): BlockMetrics {
   const valid = block.trials.filter((t) => !t.isFalseStart && t.rtMs != null);
   const rts = valid.map((t) => t.rtMs as number);
   const falseStarts = block.trials.filter((t) => t.isFalseStart).length;
-  const med = rts.length > 0 ? median(rts) : 0;
-  const lapses = valid.filter((t) => t.isLapse).length;
-  const lapseRate = valid.length > 0 ? lapses / valid.length : 0;
-  const cv = rts.length > 1 ? coefficientOfVariation(rts) : 0;
   const falseStartRate = block.trials.length > 0 ? falseStarts / block.trials.length : 0;
+  // Match scorer.ts: penalize blocks with no valid trials (all missed/false-start).
+  if (valid.length === 0) {
+    return {
+      medianRtMs: PVT_B_NORMS.medianRtMs.mean + 4 * PVT_B_NORMS.medianRtMs.sd,
+      lapseRate: 1,
+      cvRt: PVT_B_NORMS.cvRt.mean + 4 * PVT_B_NORMS.cvRt.sd,
+      falseStartRate,
+      zScore: -4,
+    };
+  }
+  const med = median(rts);
+  const lapses = valid.filter((t) => t.isLapse).length;
+  const lapseRate = lapses / valid.length;
+  const cv = rts.length > 1 ? coefficientOfVariation(rts) : 0;
   const zs = [
     -zScore(med, PVT_B_NORMS.medianRtMs),
     -zScore(lapseRate, PVT_B_NORMS.lapseRate),

--- a/supabase/functions/compute-session-score/index.ts
+++ b/supabase/functions/compute-session-score/index.ts
@@ -44,29 +44,39 @@ serve(async (req) => {
   const submission = parsed.data;
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
   const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!supabaseUrl || !anonKey || !serviceRoleKey) {
+    const missing = [
+      !supabaseUrl && 'SUPABASE_URL',
+      !anonKey && 'SUPABASE_ANON_KEY',
+      !serviceRoleKey && 'SUPABASE_SERVICE_ROLE_KEY',
+    ].filter(Boolean);
+    return json({ error: 'server misconfigured', missing }, 500);
+  }
   const userJwt = auth.replace(/^Bearer /i, '');
 
   // 1) Authenticate the driver via their JWT (anon key path).
-  const userClient = createClient(supabaseUrl, Deno.env.get('SUPABASE_ANON_KEY'), {
+  const userClient = createClient(supabaseUrl, anonKey, {
     global: { headers: { Authorization: `Bearer ${userJwt}` } },
   });
   const { data: userRes, error: userErr } = await userClient.auth.getUser();
   if (userErr || !userRes.user) return json({ error: 'unauthorized' }, 401);
-  if (userRes.user.id !== submission.driverId)
-    return json({ error: 'driver id mismatch with JWT' }, 403);
 
   // 2) Service-role client for privileged writes (bypasses RLS — safe here
   //    because we just verified the driver above).
   const admin = createClient(supabaseUrl, serviceRoleKey);
 
-  // 3) Resolve driver + company policy.
+  // 3) Resolve the driver row via auth.users mapping (drivers.user_id).
+  //    The submission's driverId must match the driver row derived from the JWT.
   const { data: driver, error: dErr } = await admin
     .from('drivers')
     .select('id, company_id, status, companies!inner(block_policy)')
-    .eq('id', submission.driverId)
+    .eq('user_id', userRes.user.id)
     .single();
-  if (dErr || !driver) return json({ error: 'driver not found' }, 404);
+  if (dErr || !driver) return json({ error: 'driver not found for authenticated user' }, 404);
+  if (driver.id !== submission.driverId)
+    return json({ error: 'driver id mismatch with authenticated driver' }, 403);
   if (driver.status !== 'active') return json({ error: `driver status ${driver.status}` }, 403);
 
   const policy = BlockPolicySchema.parse(

--- a/supabase/functions/unico-webhook/index.ts
+++ b/supabase/functions/unico-webhook/index.ts
@@ -51,7 +51,12 @@ serve(async (req) => {
   }
   const p = parsed.data;
 
-  const admin = createClient(Deno.env.get('SUPABASE_URL'), Deno.env.get('SUPABASE_SERVICE_ROLE_KEY'));
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!supabaseUrl || !serviceRoleKey) {
+    return new Response('server misconfigured', { status: 500 });
+  }
+  const admin = createClient(supabaseUrl, serviceRoleKey);
 
   const autoApprove = p.livenessPassed && p.matchScore >= AUTO_APPROVE_THRESHOLD;
   const newStatus = autoApprove ? 'active' : 'pending_match';

--- a/supabase/migrations/0005_security_review_fixes.sql
+++ b/supabase/migrations/0005_security_review_fixes.sql
@@ -1,0 +1,218 @@
+-- =====================================================================
+-- 0005_security_review_fixes.sql
+-- =====================================================================
+-- Addresses critical findings from the code review:
+--  1. RLS recursion on company_members via current_company_id()
+--  2. View v_driver_latest_session bypasses RLS (missing security_invoker)
+--  3. Storage buckets without RLS isolation
+--  4. Sessions can reference a driver from another company (composite FK)
+--  5. drivers not linked to auth.users (session auth is broken today)
+--  6. persist_session_score without search_path + service_role grant
+-- =====================================================================
+
+-- 1. Break the RLS recursion: make current_company_id() SECURITY DEFINER
+--    so it reads company_members outside the caller's RLS context.
+create or replace function current_company_id() returns uuid
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select company_id from company_members where user_id = auth.uid() limit 1;
+$$;
+
+-- 2. Recreate the view with security_invoker so RLS of base tables applies.
+drop view if exists v_driver_latest_session;
+create view v_driver_latest_session
+with (security_invoker = true)
+as
+select distinct on (d.id)
+  d.id as driver_id,
+  d.company_id,
+  d.full_name,
+  d.status as driver_status,
+  s.id as session_id,
+  s.started_at,
+  s.status as session_status,
+  ss.traffic_light,
+  ss.final_score,
+  ss.blocked
+from drivers d
+left join sessions s on s.driver_id = d.id
+left join session_scores ss on ss.session_id = s.id
+order by d.id, s.started_at desc nulls last;
+
+-- 3. Composite FK: sessions.driver_id MUST match a driver in the same company.
+--    Add a unique on (id, company_id) that the FK can reference.
+alter table drivers
+  drop constraint if exists drivers_id_company_id_key;
+alter table drivers
+  add constraint drivers_id_company_id_key unique (id, company_id);
+
+alter table sessions
+  drop constraint if exists sessions_driver_company_fk;
+alter table sessions
+  add constraint sessions_driver_company_fk
+  foreign key (driver_id, company_id)
+  references drivers (id, company_id)
+  on delete restrict;
+
+-- 4. Link drivers to auth.users. Nullable for backwards compatibility with
+--    rows created before this migration (including the pilot seed). New
+--    drivers must get user_id populated during onboarding.
+alter table drivers
+  add column if not exists user_id uuid references auth.users(id) on delete set null;
+create unique index if not exists drivers_user_id_uniq on drivers (user_id)
+  where user_id is not null;
+
+-- 5. Harden persist_session_score: fix search_path + grant execute to service_role.
+--    We RE-create the function because `set search_path` can't be added via alter.
+create or replace function persist_session_score(
+  p_session_id uuid,
+  p_driver_id uuid,
+  p_company_id uuid,
+  p_payload jsonb,
+  p_output jsonb
+) returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_block jsonb;
+  v_metrics jsonb;
+  v_block_name text;
+begin
+  insert into sessions (
+    id, driver_id, company_id, started_at, completed_at,
+    status, geo_lat, geo_lng, device_fingerprint, app_version,
+    liveness_video_ref, liveness_match_score
+  )
+  values (
+    p_session_id, p_driver_id, p_company_id,
+    (p_payload->>'startedAt')::timestamptz,
+    (p_payload->>'completedAt')::timestamptz,
+    'completed',
+    nullif(p_payload->'geo'->>'lat','')::numeric,
+    nullif(p_payload->'geo'->>'lng','')::numeric,
+    p_payload->>'deviceFingerprint',
+    p_payload->>'appVersion',
+    p_payload->>'livenessVideoRef',
+    nullif(p_payload->>'livenessMatchScore','')::numeric
+  )
+  on conflict (id) do update set
+    completed_at = excluded.completed_at,
+    status = excluded.status,
+    liveness_video_ref = coalesce(excluded.liveness_video_ref, sessions.liveness_video_ref),
+    liveness_match_score = coalesce(excluded.liveness_match_score, sessions.liveness_match_score);
+
+  for v_block in select * from jsonb_array_elements(p_payload->'blocks')
+  loop
+    v_block_name := v_block->>'block';
+    v_metrics := p_output->'blockMetrics'->v_block_name;
+    insert into cognitive_results (session_id, block, raw_data, median_rt_ms, lapse_rate, cv_rt, z_score)
+    values (
+      p_session_id,
+      v_block_name::test_block,
+      v_block,
+      (v_metrics->>'medianRtMs')::numeric,
+      (v_metrics->>'lapseRate')::numeric,
+      (v_metrics->>'cvRt')::numeric,
+      (v_metrics->>'zScore')::numeric
+    )
+    on conflict (session_id, block) do update set
+      raw_data = excluded.raw_data,
+      median_rt_ms = excluded.median_rt_ms,
+      lapse_rate = excluded.lapse_rate,
+      cv_rt = excluded.cv_rt,
+      z_score = excluded.z_score;
+  end loop;
+
+  insert into subjective_results (session_id, kss, samn_perelli, hours_slept)
+  values (
+    p_session_id,
+    (p_payload->'subjective'->>'kss')::smallint,
+    (p_payload->'subjective'->>'samnPerelli')::smallint,
+    nullif(p_payload->'subjective'->>'hoursSlept','')::numeric
+  )
+  on conflict (session_id) do update set
+    kss = excluded.kss,
+    samn_perelli = excluded.samn_perelli,
+    hours_slept = excluded.hours_slept;
+
+  insert into session_scores (
+    session_id, objective_score, subjective_score, final_score,
+    traffic_light, blocked, algorithm_version
+  )
+  values (
+    p_session_id,
+    (p_output->>'objectiveScore')::numeric,
+    (p_output->>'subjectiveScore')::numeric,
+    (p_output->>'finalScore')::numeric,
+    (p_output->>'trafficLight')::traffic_light,
+    (p_output->>'blocked')::boolean,
+    coalesce(p_output->>'algorithmVersion','v1')
+  )
+  on conflict (session_id) do update set
+    objective_score = excluded.objective_score,
+    subjective_score = excluded.subjective_score,
+    final_score = excluded.final_score,
+    traffic_light = excluded.traffic_light,
+    blocked = excluded.blocked,
+    algorithm_version = excluded.algorithm_version;
+end;
+$$;
+
+revoke all on function persist_session_score(uuid, uuid, uuid, jsonb, jsonb) from public;
+grant execute on function persist_session_score(uuid, uuid, uuid, jsonb, jsonb) to service_role;
+
+-- 6. Storage RLS: isolate by the first path segment matching auth.uid().
+--    Drivers upload under `<auth.uid()>/...` and can only read their own files.
+--    Managers read anything in their company via a join on drivers.user_id.
+alter table storage.objects enable row level security;
+
+drop policy if exists "drivers upload cnh own folder" on storage.objects;
+create policy "drivers upload cnh own folder" on storage.objects
+  for insert to authenticated
+  with check (
+    bucket_id = 'cnh-photos'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "drivers read cnh own folder" on storage.objects;
+create policy "drivers read cnh own folder" on storage.objects
+  for select to authenticated
+  using (
+    bucket_id = 'cnh-photos'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "drivers upload liveness own folder" on storage.objects;
+create policy "drivers upload liveness own folder" on storage.objects
+  for insert to authenticated
+  with check (
+    bucket_id = 'liveness-videos'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "drivers read liveness own folder" on storage.objects;
+create policy "drivers read liveness own folder" on storage.objects
+  for select to authenticated
+  using (
+    bucket_id = 'liveness-videos'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Managers (company_members) can read any file in their company. They look
+-- up drivers by user_id and match against the folder prefix.
+drop policy if exists "managers read company cnh" on storage.objects;
+create policy "managers read company cnh" on storage.objects
+  for select to authenticated
+  using (
+    bucket_id in ('cnh-photos', 'liveness-videos')
+    and exists (
+      select 1 from drivers d
+      where d.user_id::text = (storage.foldername(name))[1]
+        and d.company_id = current_company_id()
+    )
+  );


### PR DESCRIPTION
## Contexto

Fix dos 7 achados 🔴 **Critical** do review (CodeRabbit + Copilot) no PR #12.

## Segurança DB (`migration 0005`)

| Fix | Impacto |
|---|---|
| `current_company_id()` → SECURITY DEFINER + fixed search_path | Quebra recursão RLS que travaria qualquer query autenticada em `company_members` |
| View `v_driver_latest_session` com `security_invoker=true` | Antes bypassava RLS — qualquer authenticated lia de todos os tenants |
| Composite FK `sessions(driver_id, company_id) → drivers(id, company_id)` | Impossível cross-company mesmo com bug no service_role |
| `drivers.user_id references auth.users(id)` | Resolve auth real — antes a edge function exigia `auth.uid() == driverId` sem qualquer garantia de schema |
| `persist_session_score` SECURITY DEFINER + search_path + GRANT EXECUTE TO service_role | Fecha vetor search-path + edge function volta a conseguir chamar a RPC |
| Storage RLS em `storage.objects` | Antes `public=false` só bloqueava anon; qualquer authenticated baixava CNH/liveness de outras transportadoras |

## Scoring

- `scorer.ts` e `_shared/scoring.ts`: blocos sem trials válidos (todos false-start) agora recebem `zScore=-4`, não 0. Antes uma sessão inválida virava verde.
- Teste novo cobre o caso: `packages/scoring/src/scorer.test.ts` — 24/24 verde.

## Edge functions

- `compute-session-score`: valida SUPABASE_URL/ANON_KEY/SERVICE_ROLE_KEY antes de criar client; 500 com lista dos missing.
- `unico-webhook`: mesma validação.
- Driver lookup via `user_id = auth.uid()`, alinhado com a nova FK.

## Dashboard

- `/analytics`: "Motoristas ativos" agora conta `driver_id` distinct via join, não contagem de rows. Null filtering em lapse_rate / median_rt / final_score antes de histograma/média.
- `/sessions/[id]`: `device_fingerprint` null-safe.
- `next` bumped `15.0.3 → 15.2.3` (**CVE-2025-29927** — auth bypass via header `x-middleware-subrequest`, CVSS 9.1).

## Test plan

- [x] `pnpm -r --filter=./packages/* test` — 24/24 verde
- [x] `pnpm -r --filter=./packages/* typecheck` — clean
- [ ] Deploy Supabase aplica 0005 (idempotente — `drop if exists` nas policies, `add constraint if not exists` na FK)
- [ ] Smoke continua 19/19
- [ ] `/analytics` renderiza sem crash
- [ ] Onboarding real: motorista novo tem `user_id` populado

## Migration compat

0005 é **idempotente** — guardas `drop if exists`/`add constraint if not exists`/`create unique index if not exists`. Re-runs seguras. Linhas existentes em `drivers` (piloto seed + 10 demo drivers) têm `user_id` nulo, que é OK — o índice é parcial (`where user_id is not null`) e a FK composta é ≥50 semanas de driver-company já consistentes (migration 0001).

## Fora de escopo (fica pra next PR)

- ~22 minor findings do CodeRabbit (markdown MD040, contraste de botão, acessibilidade, typedRoutes top-level, README link morto, etc).
- Fechar PR #12 — vou fechar manualmente.

https://claude.ai/code/session_01TSuXQbBq2zRFv1BpXRun8o