### PR TITLE
ci(vercel): bridge env vars from vercel pull into next build

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -68,11 +68,47 @@ jobs:
           echo "pull exit: $pull_status"
           if [ $pull_status -ne 0 ]; then exit $pull_status; fi
 
+          # Diagnose + bridge env vars from .vercel/.env.production.local into
+          # the next build.
+          #
+          # Why this step exists: `vercel build` outside Vercel's cloud runs
+          # with "WARNING! Build not running on Vercel. System environment
+          # variables will not be available." — vars from
+          # .vercel/.env.production.local are NOT propagated into the
+          # subprocess that runs the custom buildCommand (`pnpm next build`).
+          # Empirically: Next.js cannot see NEXT_PUBLIC_* and fails prerender,
+          # or (worse) succeeds but ships an empty client bundle with no
+          # NEXT_PUBLIC_* baked in, breaking the login page at runtime.
+          #
+          # Fix: (1) export every var from the pull file into the current
+          # shell so `vercel build` inherits them, AND (2) copy the same file
+          # into apps/dashboard/.env.production.local so Next.js's native
+          # dotenv loader picks it up during `next build` regardless.
+          echo ""
+          echo "=== env bridge (.vercel/.env.production.local -> shell + apps/dashboard) ==="
+          ENV_FILE=.vercel/.env.production.local
+          if [ ! -f "$ENV_FILE" ]; then
+            echo "::error::$ENV_FILE not found after vercel pull; aborting"
+            exit 1
+          fi
+          # keys-only diagnostic (values stay hidden)
+          grep -oE '^[A-Za-z_][A-Za-z0-9_]*' "$ENV_FILE" | sort -u | sed 's/^/key: /'
+          echo "NEXT_PUBLIC_* keys present: $(grep -cE '^NEXT_PUBLIC_' "$ENV_FILE")"
+          set -a
+          # shellcheck disable=SC1090
+          . "$ENV_FILE"
+          set +a
+          mkdir -p apps/dashboard
+          cp "$ENV_FILE" apps/dashboard/.env.production.local
+          echo "copied -> apps/dashboard/.env.production.local"
+
           echo ""
           echo "=== vercel build ==="
           pnpm dlx vercel build --prod --token="$VERCEL_TOKEN"
           build_status=$?
           echo "build exit: $build_status"
+          # Scrub secret file before any later step can archive logs/artifacts.
+          rm -f apps/dashboard/.env.production.local
           if [ $build_status -ne 0 ]; then exit $build_status; fi
 
           echo ""


### PR DESCRIPTION
## Root cause (confirmed via the deploy log posted to issue #3)

The `vercel build` step in `deploy-dashboard.yml` was failing with:

```
WARNING! Build not running on Vercel. System environment variables will not be available.
...
Error: Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY.
    at Object.<anonymous> (supabase-server.ts)
Export encountered an error on /drivers/page: /drivers, exiting the build.
```

`vercel pull --environment=production` correctly downloads env vars to `.vercel/.env.production.local` (confirmed in the log: `Created .vercel/.env.production.local file [61ms]`), but when `vercel build` runs locally (not on Vercel's cloud) and invokes a custom `buildCommand` (`pnpm next build`) via `vercel.json`, those vars are **not** propagated into the subprocess `process.env`. Next.js 15 therefore:

- cannot inline `NEXT_PUBLIC_*` into the client bundle (→ the original symptom: the login page showed `@supabase/ssr: Your project's URL and API key are required`), and
- more recently, fails prerender of `/drivers` and `/analytics` outright (after the `getSupabaseServerClient` guard was added in `8945582`).

So the build has been failing since `f6edc46` once the env guard landed; before that, it "succeeded" but shipped a broken client bundle.

## Fix

After `vercel pull`, bridge the env file into the build two ways (belt + suspenders):

1. **Shell export.** `set -a; . .vercel/.env.production.local; set +a` so the subsequent `vercel build` (and every child process of it) inherits the vars. Handles the Vercel-CLI-as-wrapper path.
2. **Dotenv drop.** Copy the same file to `apps/dashboard/.env.production.local` so Next.js's native dotenv loader picks it up during `next build` regardless of what the Vercel CLI forwards. Authoritative fallback.

Also added a keys-only diagnostic that prints how many `NEXT_PUBLIC_*` keys landed in the pull file, so the next time something goes sideways in the Vercel env scope we see it immediately in the deploy log on issue #3.

The copied `apps/dashboard/.env.production.local` is removed right after `vercel build` exits (regardless of outcome) so no plaintext secret file ever lands in an artifact or cache. `.env.*.local` is already gitignored at repo root, so no risk of commit either.

## Test plan

- [ ] Merge to main (or run `workflow_dispatch` on `Deploy dashboard (Vercel)`). The new `=== env bridge ===` block in the deploy log should print something like `NEXT_PUBLIC_* keys present: 2`.
- [ ] Confirm `vercel build` reaches `Generating static pages (8/8)` and `Build Completed in .vercel/output` — no prerender error on `/drivers` or `/analytics`.
- [ ] Confirm `vercel deploy --prebuilt` uploads and aliases to `https://appmotoristas.vercel.app`.
- [ ] Hit `https://appmotoristas.vercel.app/login` — the build marker line should show `env-url: ✓ ok · env-key: ✓ ok`.
- [ ] Follow-up: remove the debug marker / `build: <sha>` footer from `src/app/login/page.tsx`.

## Notes

- Does **not** change `vercel.json`, `next.config.mjs`, `package.json`, or any app code. The problem was purely in how the workflow bridged env from the Vercel pull step into the build.
- If the diagnostic shows `NEXT_PUBLIC_* keys present: 0`, the root cause is at the Vercel project level (env vars not scoped to Production), not the pipeline — at which point we know to go fix the Vercel dashboard rather than touching code.

https://claude.ai/code/session_01X3q7um6CPMSFZPpWwArvgw