### PR TITLE
ci(vercel): keep env file through the deploy upload step

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -165,12 +165,19 @@ jobs:
           pnpm dlx vercel build --prod --token="$VERCEL_TOKEN"
           build_status=$?
           echo "build exit: $build_status"
-          # Scrub secret file before any later step can archive logs/artifacts.
-          rm -f apps/dashboard/.env.production.local
-          if [ $build_status -ne 0 ]; then exit $build_status; fi
+          if [ $build_status -ne 0 ]; then
+            rm -f apps/dashboard/.env.production.local
+            exit $build_status
+          fi
 
           echo ""
           echo "=== vercel deploy --prebuilt ==="
+          # Keep apps/dashboard/.env.production.local on disk through the
+          # deploy step: `vercel deploy --prebuilt` re-validates project files
+          # against .vercel/output metadata and errors with
+          # `File does not exist: "apps/dashboard/.env.production.local"` if
+          # we scrub it here. The values it contains are all NEXT_PUBLIC_*
+          # (already public by design), so uploading them is a non-issue.
           for attempt in 1 2 3; do
             echo "attempt $attempt"
             pnpm dlx vercel deploy --prebuilt --prod --yes --token="$VERCEL_TOKEN" 2>&1 | tee deploy-url.txt
@@ -180,6 +187,8 @@ jobs:
             sleep 10
           done
           echo "deploy exit: $deploy_status"
+          # Scrub only after deploy completes (or exhausts retries).
+          rm -f apps/dashboard/.env.production.local
           exit $deploy_status
 
       - name: Post log to issue #3


### PR DESCRIPTION
## Summary

The previous PR (#15) proved the env bridge works at build time. Build completed, 8/8 static pages generated. Only the deploy-upload step failed because I was scrubbing `apps/dashboard/.env.production.local` too early — between build and deploy. `vercel deploy --prebuilt` re-validates project input files and errored:

```
Error: File does not exist: "apps/dashboard/.env.production.local"
```

This PR moves the `rm` to run only after the deploy loop (or on build failure). The file only contains `NEXT_PUBLIC_*` values, which are public by design, so carrying it through upload is fine.

## Test plan

- [ ] Merge to main. New deploy log on issue #3 should show `deploy exit: 0` and an `Aliased: https://appmotoristas.vercel.app` line.
- [ ] `/login` should render with `env-url: ✓ ok · env-key: ✓ ok` in the debug marker.

https://claude.ai/code/session_01X3q7um6CPMSFZPpWwArvgw

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3q7um6CPMSFZPpWwArvgw)_