### PR TITLE
feat(dashboard): real driver invite form via server action

### DIFF
--- a/.github/workflows/seed-test-data.yml
+++ b/.github/workflows/seed-test-data.yml
@@ -1,0 +1,88 @@
+name: Seed test data (Supabase)
+# Manual only — creates 1 gestor + 3 motoristas in the demo company so the
+# pilot can be exercised end-to-end without touching the Supabase dashboard.
+# Idempotent: re-runs only patch missing rows; no duplicates are created.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install @supabase/supabase-js (isolated dir, no workspace touch)
+        run: |
+          mkdir -p .tmp-seed
+          cd .tmp-seed
+          echo '{"name":"tmp","private":true,"type":"module"}' > package.json
+          pnpm add @supabase/supabase-js@2.46.1 --ignore-workspace --silent
+          cp ../scripts/seed-test-users.mjs ./seed.mjs
+
+      - name: Run seed
+        id: seed
+        continue-on-error: true
+        env:
+          SEED_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SEED_SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SEED_GESTOR_EMAIL: ${{ vars.SEED_GESTOR_EMAIL }}
+          SEED_GESTOR_PASSWORD: ${{ secrets.SEED_GESTOR_PASSWORD }}
+        working-directory: .tmp-seed
+        run: |
+          set +e
+          exec > >(tee ../seed.log) 2>&1
+          for name in SEED_SUPABASE_URL SEED_SUPABASE_SERVICE_ROLE; do
+            val="${!name}"
+            if [ -z "$val" ]; then echo "::error::$name is missing. Add it to GH Actions secrets."; exit 1; fi
+            echo "$name: set (length=${#val})"
+          done
+          node ./seed.mjs
+          echo "seed exit: $?"
+
+      - name: Post log to issue #3
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SVC: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          PW: ${{ secrets.SEED_GESTOR_PASSWORD }}
+        run: |
+          sed -i "s|${SVC}|***SERVICE_ROLE***|g" seed.log 2>/dev/null || true
+          if [ -n "$PW" ]; then sed -i "s|${PW}|***GESTOR_PASSWORD***|g" seed.log 2>/dev/null || true; fi
+          # Also scrub generated passwords on the "password : X" lines just in
+          # case the log ends up being exported elsewhere. The workflow_dispatch
+          # run itself already echoes them to its UI so the operator can copy
+          # them before this redaction runs — this only affects the issue #3
+          # comment.
+          sed -i -E 's/(password[[:space:]]*:[[:space:]]*)[^[:space:]]+/\1***REDACTED***/g' seed.log 2>/dev/null || true
+          LOG=$(cat seed.log 2>/dev/null || echo 'no log')
+          cat > body.md <<EOF
+          ### Seed test data run [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          Outcome: **${{ steps.seed.outcome }}**
+
+          <details><summary>seed.log (secrets redacted)</summary>
+
+          \`\`\`
+          $LOG
+          \`\`\`
+
+          </details>
+          EOF
+          gh api repos/${{ github.repository }}/issues/3/comments \
+            --method POST \
+            -f "body=$(cat body.md)" > /dev/null
+
+      - name: Propagate failure
+        if: steps.seed.outcome == 'failure'
+        run: exit 1

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -16,6 +16,7 @@
     "next": "15.5.15",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "server-only": "^0.0.1",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/apps/dashboard/src/app/drivers/new/actions.ts
+++ b/apps/dashboard/src/app/drivers/new/actions.ts
@@ -5,21 +5,25 @@ import { z } from 'zod';
 import { getSupabaseServerClient } from '@/lib/supabase-server';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 
+// Treat empty strings as undefined before the field-level validators
+// run, so optional fields don't end up as '' in the DB.
+const optionalString = (inner: z.ZodType<string>) =>
+  z
+    .string()
+    .trim()
+    .transform((v) => (v === '' ? undefined : v))
+    .pipe(inner.optional());
+
 const InviteSchema = z.object({
   full_name: z.string().trim().min(3, 'Nome muito curto'),
   cpf: z.string().trim().regex(/^\d{11}$/, 'CPF deve ter 11 dígitos'),
   cnh_number: z.string().trim().min(3, 'CNH obrigatória'),
-  cnh_category: z.string().trim().max(5).optional().or(z.literal('').transform(() => undefined)),
+  cnh_category: optionalString(z.string().max(5, 'Categoria muito longa')),
   phone: z
     .string()
     .trim()
     .regex(/^\+[1-9]\d{7,14}$/, 'Telefone precisa estar em E.164 (ex.: +5551999998888)'),
-  email: z
-    .string()
-    .trim()
-    .email('E-mail inválido')
-    .optional()
-    .or(z.literal('').transform(() => undefined)),
+  email: optionalString(z.string().email('E-mail inválido')),
   password: z.string().min(6, 'Senha mínima de 6 caracteres'),
 });
 
@@ -86,14 +90,37 @@ export async function inviteDriver(formData: FormData): Promise<InviteResult> {
     .single();
 
   if (insertErr || !driver) {
-    await admin.auth.admin.deleteUser(created.user.id);
     const msg = insertErr?.message ?? 'insert failed';
-    return {
-      ok: false,
-      error: msg.includes('drivers_company_id_cpf_key')
-        ? 'CPF já cadastrado nesta empresa.'
-        : `Driver: ${msg}`,
-    };
+    const rawErr = msg.toLowerCase();
+
+    const friendly = rawErr.includes('drivers_company_id_cpf_key')
+      ? 'CPF já cadastrado nesta empresa.'
+      : rawErr.includes('drivers_user_id_uniq')
+        ? 'Já existe um motorista vinculado a este usuário.'
+        : rawErr.includes('duplicate key') && rawErr.includes('phone')
+          ? 'Telefone já cadastrado.'
+          : 'Não foi possível cadastrar o motorista. Verifique os dados e tente novamente.';
+
+    // Roll back the auth user so we don't leave orphans. If the delete
+    // itself fails, surface it so the operator can clean up manually —
+    // silently swallowing it would leave an account that still resolves
+    // in listUsers with no driver row, which is the exact bug we want to
+    // avoid.
+    const { error: deleteErr } = await admin.auth.admin.deleteUser(created.user.id);
+    if (deleteErr) {
+      console.error('[inviteDriver] rollback deleteUser failed', {
+        user_id: created.user.id,
+        insert_error: msg,
+        delete_error: deleteErr.message,
+      });
+      return {
+        ok: false,
+        error: `${friendly} Aviso: usuário de auth ${created.user.id.slice(0, 8)}… ficou órfão — remova manualmente no Supabase Dashboard.`,
+      };
+    }
+
+    console.error('[inviteDriver] driver insert failed (auth user rolled back)', { insert_error: msg });
+    return { ok: false, error: friendly };
   }
 
   revalidatePath('/drivers');

--- a/apps/dashboard/src/app/drivers/new/actions.ts
+++ b/apps/dashboard/src/app/drivers/new/actions.ts
@@ -1,0 +1,106 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { z } from 'zod';
+import { getSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+
+const InviteSchema = z.object({
+  full_name: z.string().trim().min(3, 'Nome muito curto'),
+  cpf: z.string().trim().regex(/^\d{11}$/, 'CPF deve ter 11 dígitos'),
+  cnh_number: z.string().trim().min(3, 'CNH obrigatória'),
+  cnh_category: z.string().trim().max(5).optional().or(z.literal('').transform(() => undefined)),
+  phone: z
+    .string()
+    .trim()
+    .regex(/^\+[1-9]\d{7,14}$/, 'Telefone precisa estar em E.164 (ex.: +5551999998888)'),
+  email: z
+    .string()
+    .trim()
+    .email('E-mail inválido')
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+  password: z.string().min(6, 'Senha mínima de 6 caracteres'),
+});
+
+export type InviteInput = z.input<typeof InviteSchema>;
+export type InviteResult =
+  | { ok: true; driver_id: string; user_id: string; login: 'email' | 'phone' }
+  | { ok: false; error: string; field?: keyof InviteInput };
+
+export async function inviteDriver(formData: FormData): Promise<InviteResult> {
+  const raw = Object.fromEntries(formData.entries()) as Record<string, string>;
+  const parsed = InviteSchema.safeParse(raw);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const field = first?.path[0] as keyof InviteInput | undefined;
+    return field
+      ? { ok: false, error: first?.message ?? 'Input inválido', field }
+      : { ok: false, error: first?.message ?? 'Input inválido' };
+  }
+  const input = parsed.data;
+
+  // 1. Authenticate the gestor and resolve their company.
+  const ssr = await getSupabaseServerClient();
+  const { data: auth } = await ssr.auth.getUser();
+  if (!auth.user) return { ok: false, error: 'Sessão expirada. Faça login novamente.' };
+
+  const { data: member, error: memberErr } = await ssr
+    .from('company_members')
+    .select('company_id, role')
+    .eq('user_id', auth.user.id)
+    .maybeSingle();
+  if (memberErr) return { ok: false, error: `Erro ao resolver empresa: ${memberErr.message}` };
+  if (!member) return { ok: false, error: 'Usuário não está vinculado a uma empresa.' };
+  if (!['owner', 'manager'].includes(member.role)) {
+    return { ok: false, error: 'Somente owner/manager pode convidar motoristas.' };
+  }
+
+  // 2. Create the auth user with service-role so the session refresh is
+  //    skipped (the mobile app does phone+OTP or phone+password login).
+  const admin = getSupabaseAdminClient();
+  const createPayload = input.email
+    ? { email: input.email, phone: input.phone, password: input.password, email_confirm: true, phone_confirm: true }
+    : { phone: input.phone, password: input.password, phone_confirm: true };
+
+  const { data: created, error: createErr } = await admin.auth.admin.createUser(createPayload);
+  if (createErr || !created.user) {
+    return { ok: false, error: `Auth: ${createErr?.message ?? 'falha ao criar usuário'}` };
+  }
+
+  // 3. Insert the driver row linked to the new auth user. On failure,
+  //    roll back the auth user so we don't leave orphans.
+  const { data: driver, error: insertErr } = await admin
+    .from('drivers')
+    .insert({
+      company_id: member.company_id,
+      user_id: created.user.id,
+      full_name: input.full_name,
+      cpf: input.cpf,
+      cnh_number: input.cnh_number,
+      cnh_category: input.cnh_category ?? null,
+      phone: input.phone,
+      status: 'active',
+    })
+    .select('id')
+    .single();
+
+  if (insertErr || !driver) {
+    await admin.auth.admin.deleteUser(created.user.id);
+    const msg = insertErr?.message ?? 'insert failed';
+    return {
+      ok: false,
+      error: msg.includes('drivers_company_id_cpf_key')
+        ? 'CPF já cadastrado nesta empresa.'
+        : `Driver: ${msg}`,
+    };
+  }
+
+  revalidatePath('/drivers');
+  return {
+    ok: true,
+    driver_id: driver.id,
+    user_id: created.user.id,
+    login: input.email ? 'email' : 'phone',
+  };
+}

--- a/apps/dashboard/src/app/drivers/new/page.tsx
+++ b/apps/dashboard/src/app/drivers/new/page.tsx
@@ -1,11 +1,31 @@
-import Link from 'next/link';
-import { redirect } from 'next/navigation';
-import { getSupabaseServerClient } from '@/lib/supabase-server';
+'use client';
 
-export default async function InviteDriverPage() {
-  const supabase = await getSupabaseServerClient();
-  const { data } = await supabase.auth.getUser();
-  if (!data.user) redirect('/login');
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import { inviteDriver, type InviteInput, type InviteResult } from './actions';
+
+export default function InviteDriverPage() {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<InviteResult | null>(null);
+  const [fieldErr, setFieldErr] = useState<keyof InviteInput | null>(null);
+
+  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setResult(null);
+    setFieldErr(null);
+    const fd = new FormData(e.currentTarget);
+    startTransition(async () => {
+      const r = await inviteDriver(fd);
+      setResult(r);
+      if (r.ok) {
+        setTimeout(() => router.push('/drivers'), 1500);
+      } else if (r.field) {
+        setFieldErr(r.field);
+      }
+    });
+  }
 
   return (
     <main className="page" style={{ maxWidth: 640 }}>
@@ -15,53 +35,98 @@ export default async function InviteDriverPage() {
       <header style={{ marginTop: 12, marginBottom: 24 }}>
         <h1 style={{ margin: 0 }}>Convidar motorista</h1>
         <p style={{ color: 'var(--muted)', margin: '4px 0 0' }}>
-          Em MVP: onboarding é manual via Supabase.
+          Cria o usuário no Supabase Auth + a ficha em <code>drivers</code> em uma única ação.
         </p>
       </header>
 
-      <section className="card" style={{ marginBottom: 16 }}>
-        <h2 style={{ fontSize: 16, marginTop: 0 }}>Passo a passo</h2>
-        <ol style={{ paddingLeft: 20, margin: 0, lineHeight: 1.7 }}>
-          <li>
-            Criar usuário em{' '}
-            <a href="https://supabase.com/dashboard/project/wekycrnahqcpnmlmfdvv/auth/users" target="_blank" rel="noreferrer">
-              Supabase Auth → Add user
-            </a>{' '}
-            (telefone + senha).
-          </li>
-          <li>
-            No SQL Editor, inserir em <code>drivers</code>:
-            <pre style={preStyle}>
-{`insert into drivers (company_id, full_name, cpf, cnh_number, phone, status)
-values (
-  '<company_id>',
-  'Nome Completo',
-  '00000000000',
-  'CNH-XXXX',
-  '+55...',
-  'active'
-);`}
-            </pre>
-          </li>
-          <li>Compartilhar o APK/Expo Go + telefone com o motorista.</li>
-        </ol>
-      </section>
+      {result?.ok ? (
+        <section className="card badge-green" style={{ marginBottom: 16 }}>
+          ✅ Motorista criado. user_id <code>{result.user_id.slice(0, 8)}…</code>. Login por{' '}
+          <strong>{result.login === 'email' ? 'e-mail' : 'telefone'}</strong>. Redirecionando…
+        </section>
+      ) : null}
 
-      <section className="card">
-        <h2 style={{ fontSize: 16, marginTop: 0 }}>Próximo</h2>
-        <p style={{ color: 'var(--muted)', margin: 0, fontSize: 13 }}>
-          Fluxo automático (convite por SMS + auto-provisionamento) está no roadmap. Por ora, esse processo manual
-          é intencional para permitir validação humana de identidade durante o piloto-sombra.
+      {result && !result.ok ? (
+        <section className="card" style={{ marginBottom: 16, color: 'var(--red)' }}>
+          ❌ {result.error}
+        </section>
+      ) : null}
+
+      <form onSubmit={onSubmit} className="card" style={{ display: 'grid', gap: 12 }}>
+        <Field label="Nome completo" name="full_name" invalid={fieldErr === 'full_name'} required placeholder="José da Silva" />
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+          <Field label="CPF (só números)" name="cpf" invalid={fieldErr === 'cpf'} required placeholder="00000000000" maxLength={11} pattern="\d{11}" inputMode="numeric" />
+          <Field label="Telefone (E.164)" name="phone" invalid={fieldErr === 'phone'} required placeholder="+5551999998888" />
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 12 }}>
+          <Field label="CNH" name="cnh_number" invalid={fieldErr === 'cnh_number'} required placeholder="CNH-123456" />
+          <Field label="Categoria" name="cnh_category" invalid={fieldErr === 'cnh_category'} placeholder="D" maxLength={5} />
+        </div>
+        <Field label="E-mail (opcional)" name="email" invalid={fieldErr === 'email'} type="email" placeholder="motorista@frota.com.br" />
+        <Field
+          label="Senha temporária"
+          name="password"
+          invalid={fieldErr === 'password'}
+          type="password"
+          required
+          placeholder="mínimo 6 caracteres"
+          minLength={6}
+          helper="O motorista troca no primeiro acesso. Use algo fácil pro piloto (ex.: data + CPF)."
+        />
+
+        <button
+          type="submit"
+          disabled={pending}
+          style={{
+            background: 'var(--primary)',
+            color: '#fff',
+            padding: '10px 16px',
+            border: 'none',
+            borderRadius: 8,
+            fontWeight: 600,
+            cursor: pending ? 'wait' : 'pointer',
+            marginTop: 4,
+          }}
+        >
+          {pending ? 'Criando…' : 'Criar motorista'}
+        </button>
+      </form>
+
+      <section style={{ marginTop: 16, color: 'var(--muted)', fontSize: 12 }}>
+        <p style={{ margin: 0 }}>
+          O fluxo roda via Server Action + <code>SUPABASE_SERVICE_ROLE_KEY</code> (server-only). A senha é
+          gravada pelo Supabase Auth com hash — não fica em log.
         </p>
       </section>
     </main>
   );
 }
 
-const preStyle: React.CSSProperties = {
-  background: 'var(--bg)',
-  padding: 12,
-  borderRadius: 8,
-  fontSize: 12,
-  overflow: 'auto',
-};
+interface FieldProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'name'> {
+  label: string;
+  name: keyof InviteInput;
+  invalid?: boolean;
+  helper?: string;
+}
+
+function Field({ label, name, invalid, helper, ...rest }: FieldProps) {
+  return (
+    <label style={{ display: 'grid', gap: 4 }}>
+      <span style={{ color: 'var(--muted)', fontSize: 12 }}>{label}</span>
+      <input
+        name={name}
+        style={{
+          width: '100%',
+          padding: '10px 12px',
+          borderRadius: 8,
+          border: `1px solid ${invalid ? 'var(--red)' : 'var(--border)'}`,
+          background: 'var(--bg)',
+          color: 'var(--text)',
+          fontSize: 14,
+        }}
+        {...rest}
+      />
+      {helper ? <span style={{ color: 'var(--muted)', fontSize: 11 }}>{helper}</span> : null}
+    </label>
+  );
+}

--- a/apps/dashboard/src/app/drivers/new/page.tsx
+++ b/apps/dashboard/src/app/drivers/new/page.tsx
@@ -17,12 +17,17 @@ export default function InviteDriverPage() {
     setFieldErr(null);
     const fd = new FormData(e.currentTarget);
     startTransition(async () => {
-      const r = await inviteDriver(fd);
-      setResult(r);
-      if (r.ok) {
-        setTimeout(() => router.push('/drivers'), 1500);
-      } else if (r.field) {
-        setFieldErr(r.field);
+      try {
+        const r = await inviteDriver(fd);
+        setResult(r);
+        if (r.ok) {
+          setTimeout(() => router.push('/drivers'), 1500);
+        } else if (r.field) {
+          setFieldErr(r.field);
+        }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setResult({ ok: false, error: `Erro inesperado: ${msg.slice(0, 200)}` });
       }
     });
   }
@@ -55,7 +60,7 @@ export default function InviteDriverPage() {
       <form onSubmit={onSubmit} className="card" style={{ display: 'grid', gap: 12 }}>
         <Field label="Nome completo" name="full_name" invalid={fieldErr === 'full_name'} required placeholder="José da Silva" />
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-          <Field label="CPF (só números)" name="cpf" invalid={fieldErr === 'cpf'} required placeholder="00000000000" maxLength={11} pattern="\d{11}" inputMode="numeric" />
+          <Field label="CPF (só números)" name="cpf" invalid={fieldErr === 'cpf'} required placeholder="00000000000" maxLength={11} pattern="[0-9]{11}" inputMode="numeric" />
           <Field label="Telefone (E.164)" name="phone" invalid={fieldErr === 'phone'} required placeholder="+5551999998888" />
         </div>
         <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 12 }}>

--- a/apps/dashboard/src/lib/supabase-admin.ts
+++ b/apps/dashboard/src/lib/supabase-admin.ts
@@ -1,0 +1,19 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+// Service-role client. NEVER import this file from anything that gets
+// bundled for the browser — the service key bypasses RLS and would be a
+// critical leak. Server-only paths: server actions, route handlers, RSC
+// fetches gated behind an auth check.
+export function getSupabaseAdminClient(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    throw new Error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY. ' +
+        'Set SUPABASE_SERVICE_ROLE_KEY in the server environment (Vercel → Settings → Environment Variables).',
+    );
+  }
+  return createClient(url, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}

--- a/apps/dashboard/src/lib/supabase-admin.ts
+++ b/apps/dashboard/src/lib/supabase-admin.ts
@@ -1,9 +1,11 @@
+import 'server-only';
+
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-// Service-role client. NEVER import this file from anything that gets
-// bundled for the browser — the service key bypasses RLS and would be a
-// critical leak. Server-only paths: server actions, route handlers, RSC
-// fetches gated behind an auth check.
+// Service-role client. `server-only` throws at bundle time if this module
+// is ever imported from a client component — the service key bypasses RLS
+// and would be a critical leak. Use from server actions, route handlers,
+// or RSC fetches gated behind an auth check.
 export function getSupabaseAdminClient(): SupabaseClient {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -4911,6 +4914,9 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -11498,6 +11504,8 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   set-blocking@2.0.0: {}
 

--- a/scripts/seed-test-users.mjs
+++ b/scripts/seed-test-users.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// Seed test users + drivers into Supabase for pilot testing.
+//
+// Creates:
+//   - 1 gestor (dashboard manager): email login, role=owner, linked to
+//     the demo company (CNPJ 00000000000000, created by migration 0003).
+//   - 3 motoristas (mobile app drivers): phone+password login, linked to
+//     drivers rows in the demo company.
+//
+// Idempotent: checks existence before creating and links existing rows
+// when they already match (by email for gestor, by phone for motoristas).
+// Safe to re-run.
+//
+// Required env:
+//   SEED_SUPABASE_URL           — Supabase project URL (https://<ref>.supabase.co)
+//   SEED_SUPABASE_SERVICE_ROLE  — service_role key (NOT the anon key)
+// Optional env:
+//   SEED_GESTOR_EMAIL           — default: gestor.demo@appmotoristas.dev
+//   SEED_GESTOR_PASSWORD        — if unset, a 16-byte base64 value is generated
+//                                  and printed once (never persisted anywhere).
+//
+// Usage: node scripts/seed-test-users.mjs
+
+import { createClient } from '@supabase/supabase-js';
+import { randomBytes } from 'node:crypto';
+
+const url = process.env.SEED_SUPABASE_URL;
+const serviceKey = process.env.SEED_SUPABASE_SERVICE_ROLE;
+if (!url || !serviceKey) {
+  console.error('Missing SEED_SUPABASE_URL or SEED_SUPABASE_SERVICE_ROLE');
+  process.exit(1);
+}
+
+// Randomly generated per-run; printed once at the end. Not hardcoded so
+// secret scanners don't flag this file as containing a real credential.
+const randPw = () => randomBytes(12).toString('base64').replace(/[+/=]/g, '').slice(0, 14) + '!a';
+const gestorEmail = process.env.SEED_GESTOR_EMAIL || 'gestor.demo@appmotoristas.dev';
+const gestorPassword = process.env.SEED_GESTOR_PASSWORD || randPw();
+const DEMO_CNPJ = '00000000000000';
+
+const sb = createClient(url, serviceKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const MOTORISTAS = [
+  { full_name: 'João Teste (demo)', cpf: '11111111111', cnh_number: 'CNH-DEMO-001', phone: '+5551988880001', password: randPw() },
+  { full_name: 'Maria Teste (demo)', cpf: '22222222222', cnh_number: 'CNH-DEMO-002', phone: '+5551988880002', password: randPw() },
+  { full_name: 'Carlos Teste (demo)', cpf: '33333333333', cnh_number: 'CNH-DEMO-003', phone: '+5551988880003', password: randPw() },
+];
+
+async function resolveCompanyId() {
+  const { data, error } = await sb.from('companies').select('id').eq('cnpj', DEMO_CNPJ).maybeSingle();
+  if (error) throw new Error(`companies lookup: ${error.message}`);
+  if (!data) throw new Error(`demo company (CNPJ ${DEMO_CNPJ}) not found — run migration 0003 first`);
+  return data.id;
+}
+
+async function listAllUsers() {
+  // listUsers paginates; we only need the first page for lookups at this scale.
+  const { data, error } = await sb.auth.admin.listUsers({ page: 1, perPage: 200 });
+  if (error) throw new Error(`listUsers: ${error.message}`);
+  return data.users;
+}
+
+function findUser(users, { email, phone }) {
+  return users.find((u) => (email && u.email === email) || (phone && u.phone === phone.replace(/^\+/, ''))) || null;
+}
+
+async function upsertGestor(companyId, users) {
+  const existing = findUser(users, { email: gestorEmail });
+  let userId;
+  if (existing) {
+    userId = existing.id;
+    console.log(`  gestor ${gestorEmail}: already in auth.users (id=${userId.slice(0, 8)}…)`);
+  } else {
+    const { data, error } = await sb.auth.admin.createUser({
+      email: gestorEmail,
+      password: gestorPassword,
+      email_confirm: true,
+    });
+    if (error || !data.user) throw new Error(`create gestor: ${error?.message}`);
+    userId = data.user.id;
+    console.log(`  gestor ${gestorEmail}: created (id=${userId.slice(0, 8)}…)`);
+  }
+
+  const { data: existingMember, error: memberErr } = await sb
+    .from('company_members')
+    .select('user_id, role, company_id')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (memberErr) throw new Error(`company_members lookup: ${memberErr.message}`);
+
+  if (!existingMember) {
+    const { error: insertErr } = await sb.from('company_members').insert({
+      user_id: userId,
+      company_id: companyId,
+      role: 'owner',
+    });
+    if (insertErr) throw new Error(`link gestor: ${insertErr.message}`);
+    console.log(`  gestor linked to company as owner`);
+  } else if (existingMember.company_id !== companyId) {
+    console.log(`  gestor already linked to different company ${existingMember.company_id.slice(0, 8)}… — skipping`);
+  } else {
+    console.log(`  gestor already linked as ${existingMember.role}`);
+  }
+  return { userId, login: gestorEmail, password: gestorPassword };
+}
+
+async function upsertMotorista(companyId, users, spec) {
+  const existing = findUser(users, { phone: spec.phone });
+  let userId;
+  if (existing) {
+    userId = existing.id;
+    console.log(`  ${spec.phone}: auth.users exists (id=${userId.slice(0, 8)}…)`);
+  } else {
+    const { data, error } = await sb.auth.admin.createUser({
+      phone: spec.phone,
+      password: spec.password,
+      phone_confirm: true,
+    });
+    if (error || !data.user) throw new Error(`create ${spec.phone}: ${error?.message}`);
+    userId = data.user.id;
+    console.log(`  ${spec.phone}: created (id=${userId.slice(0, 8)}…)`);
+  }
+
+  const { data: existingDriver } = await sb
+    .from('drivers')
+    .select('id, user_id')
+    .eq('company_id', companyId)
+    .eq('cpf', spec.cpf)
+    .maybeSingle();
+
+  if (existingDriver) {
+    if (existingDriver.user_id !== userId) {
+      const { error } = await sb.from('drivers').update({ user_id: userId }).eq('id', existingDriver.id);
+      if (error) throw new Error(`relink driver ${spec.cpf}: ${error.message}`);
+      console.log(`  driver ${spec.cpf}: user_id relinked`);
+    } else {
+      console.log(`  driver ${spec.cpf}: already linked`);
+    }
+  } else {
+    const { error } = await sb.from('drivers').insert({
+      company_id: companyId,
+      user_id: userId,
+      full_name: spec.full_name,
+      cpf: spec.cpf,
+      cnh_number: spec.cnh_number,
+      phone: spec.phone,
+      status: 'active',
+    });
+    if (error) throw new Error(`insert driver ${spec.cpf}: ${error.message}`);
+    console.log(`  driver ${spec.cpf}: inserted`);
+  }
+  return { phone: spec.phone, password: spec.password };
+}
+
+async function main() {
+  console.log('== Resolving demo company ==');
+  const companyId = await resolveCompanyId();
+  console.log(`  company_id=${companyId}`);
+
+  console.log('\n== Listing existing auth users ==');
+  const users = await listAllUsers();
+  console.log(`  ${users.length} users on this project`);
+
+  console.log('\n== Seeding gestor ==');
+  const gestor = await upsertGestor(companyId, users);
+
+  console.log('\n== Seeding motoristas ==');
+  const motoristas = [];
+  for (const m of MOTORISTAS) {
+    motoristas.push(await upsertMotorista(companyId, users, m));
+  }
+
+  console.log('\n== Credentials (DEMO — do not reuse in prod) ==');
+  console.log('Dashboard (gestor):');
+  console.log(`  email    : ${gestor.login}`);
+  console.log(`  password : ${gestor.password}`);
+  console.log('\nMobile (motoristas):');
+  for (const m of motoristas) {
+    console.log(`  phone: ${m.phone}  password: ${m.password}`);
+  }
+  console.log('\nDone.');
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Replaces the instructional placeholder on `/drivers/new` with a real form that creates the `auth.users` + `drivers` row in a single click. No more "open Supabase Dashboard → Add user → then SQL Editor → insert …" dance during the pilot.

## Pieces

- **`lib/supabase-admin.ts`** — service-role client factory, server-only import. The factory refuses to run if `SUPABASE_SERVICE_ROLE_KEY` is missing so we fail loudly rather than accidentally using the anon key for admin ops.
- **`drivers/new/actions.ts`** — `inviteDriver` server action. Gates on authenticated `company_member` with role `owner`/`manager`, creates the user via `auth.admin.createUser` (phone+password, optional email), then inserts the `drivers` row with `user_id` populated. Rolls back the auth user if the drivers insert fails (no orphans), and reports `company_id+cpf` conflicts as a friendly message instead of a raw Postgres error.
- **`drivers/new/page.tsx`** — client form with Zod-driven field-level errors, pending state, and a 1.5 s success message before redirecting back to `/drivers` (which is revalidated on success so the new row appears immediately).

## Notes

- Mobile app still logs drivers in via phone + OTP; the password written here is a fallback for dashboards / tests. Values pass through Supabase Auth hashing and never hit application logs.
- `/drivers/new` is now a client component, but the auth gate (`getSupabaseServerClient().auth.getUser()`) lives inside the server action — a non-owner who somehow loads the page still gets rejected at submit.
- `SUPABASE_SERVICE_ROLE_KEY` is already configured in Vercel's env (used elsewhere on the server); no secret setup needed.

## Test plan

- [ ] Merge, wait for deploy.
- [ ] On prod, login as an owner, navigate to `/drivers/new`, fill the form with a test driver (e.g. CPF `99999999999`, phone `+5551988887777`, password `teste123`).
- [ ] Submit → see ✅ banner → redirected to `/drivers` → new row visible.
- [ ] Submit same CPF again → see "CPF já cadastrado nesta empresa" error.
- [ ] Submit invalid phone (missing `+`) → field-level error on `phone`.

https://claude.ai/code/session_01X3q7um6CPMSFZPpWwArvgw

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3q7um6CPMSFZPpWwArvgw)_