### PR TITLE
fix(dashboard): mark auth-gated pages as force-dynamic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 build/
 .next/
+next-env.d.ts
 .expo/
 .turbo/
 coverage/

--- a/apps/dashboard/src/app/analytics/page.tsx
+++ b/apps/dashboard/src/app/analytics/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getSupabaseServerClient } from '@/lib/supabase-server';
 
+export const dynamic = 'force-dynamic';
+
 interface CognitiveRow {
   median_rt_ms: number | null;
   lapse_rate: number | null;

--- a/apps/dashboard/src/app/drivers/page.tsx
+++ b/apps/dashboard/src/app/drivers/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getSupabaseServerClient } from '@/lib/supabase-server';
 
+export const dynamic = 'force-dynamic';
+
 interface Row {
   driver_id: string;
   full_name: string;

--- a/apps/dashboard/src/app/page.tsx
+++ b/apps/dashboard/src/app/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getSupabaseServerClient } from '@/lib/supabase-server';
 
+export const dynamic = 'force-dynamic';
+
 export default async function Home() {
   const supabase = await getSupabaseServerClient();
   const { data } = await supabase.auth.getUser();

--- a/apps/dashboard/src/app/sessions/[id]/page.tsx
+++ b/apps/dashboard/src/app/sessions/[id]/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import { getSupabaseServerClient } from '@/lib/supabase-server';
 
+export const dynamic = 'force-dynamic';
+
 export default async function SessionDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const supabase = await getSupabaseServerClient();


### PR DESCRIPTION
## Sintoma

O build no Vercel falhava em `Generating static pages`:

```
Error occurred prerendering page "/analytics".
Error: Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY.
Export encountered an error on /analytics/page: /analytics, exiting the build.
```

Reproduzido localmente com `pnpm --filter @app-motoristas/dashboard build` sem env vars.

## Causa

`/`, `/drivers`, `/analytics` e `/sessions/[id]` chamam `getSupabaseServerClient()` no topo do componente Server. Esse helper lança quando `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` não estão presentes no build. Como o Next 15 tenta prerender páginas Server por padrão, o build quebra.

## Fix

Adicionar `export const dynamic = 'force-dynamic'` nessas 4 páginas. Elas são personalizadas (auth + dados do tenant) — prerender estático nunca foi a estratégia certa.

Após o fix, o build passa:

```
Route (app)                                 Size  First Load JS
┌ ƒ /                                      169 B         106 kB
├ ƒ /analytics                             169 B         106 kB
├ ƒ /drivers                               169 B         106 kB
├ ○ /drivers/new                         2.02 kB         108 kB
├ ○ /login                               38.5 kB         141 kB
└ ƒ /sessions/[id]                         169 B         106 kB
```

`/login` e `/drivers/new` permanecem estáticas (Client Components, sem dependência de env no SSR).

## Observação sobre os builds que estão falhando agora

O log que você mandou é de uma preview do Vercel da branch `claude/driver-readiness-app-eNRUd` (commit `c9d6222`). Essa branch é antiga:

- `apps/dashboard/package.json` lá ainda tem `next: 15.0.3`
- não tem `apps/dashboard/vercel.json`
- o `pnpm-lock.yaml` lá não bate com o `package.json` (daí o `ERR_PNPM_OUTDATED_LOCKFILE`)

Esse fix aqui resolve o build da `main` (e qualquer branch derivada dela). A branch `claude/driver-readiness-app-eNRUd` continua quebrada até alguém:

1. fazer rebase/merge de `main` nela, ou
2. fechar/deletar a branch (já que tem PRs #22 e #23 abertos contra ela como base, conviria primeiro re-apontar esses PRs para `main`).

Posso fazer isso depois se você quiser — só me avisa.

## Test plan

- [x] `pnpm --filter @app-motoristas/dashboard build` passa localmente sem env vars
- [x] `pnpm --filter @app-motoristas/dashboard typecheck` limpo
- [ ] Vercel preview deste PR builda verde


---
_Generated by [Claude Code](https://claude.ai/code/session_01G9totMbBZfVHG1eFB9QpFU)_